### PR TITLE
Fixed duplication in emulated DB entries with jest global initialization | Fixed bug in orders-controller failing test

### DIFF
--- a/server/controllers/orders-controller.js
+++ b/server/controllers/orders-controller.js
@@ -41,10 +41,10 @@ exports.addOrder = async (req, res) => {
  *
  * @param {Object} req - The request.
  * @param {Object} res - The response.
- * @param {String} req.query.userId - The user id query.
+ * @param {String} req.params.userId - The user id query passed as /api/order/list/<userId>
  */
 exports.listOrders = async (req, res) => {
-  const reqQuery = req.query;
+  const reqQuery = req.params;
   let orders = [];
 
   const userId = reqQuery.userId;

--- a/server/emulatedFirestore.js
+++ b/server/emulatedFirestore.js
@@ -26,33 +26,21 @@ const setupSimulatedDB = async () => {
   console.log("setting up emulation firestore");
 
   // Add our dummy data into emulated firestore
-  const curUsers = await firestore.collection(USERS_COLLECTION).get();
-  if (true || !curUsers.docs.length) {
-    console.log("Populating USER entries");
-    for (const user of TEST_USERS) {
-      await firestore.collection(USERS_COLLECTION).add(user);
-    }
+  console.log("Populating USER entries");
+  for (const user of TEST_USERS) {
+    await firestore.collection(USERS_COLLECTION).add(user);
   }
-  const curItems = await firestore.collection(ITEMS_COLLECTION).get();
-  if (true || !curItems.docs.length) {
-    console.log("Populating ITEM entries");
-    for (const item of TEST_ITEMS) {
-      await firestore.collection(ITEMS_COLLECTION).add(item);
-    }
+  console.log("Populating ITEM entries");
+  for (const item of TEST_ITEMS) {
+    await firestore.collection(ITEMS_COLLECTION).add(item);
   }
-  const curStores = await firestore.collection(STORES_COLLECTION).get();
-  if (true || !curStores.docs.length) {
-    console.log("Populating STORE entries");
-    for (const store of TEST_STORES) {
-      await firestore.collection(STORES_COLLECTION).add(store);
-    }
+  console.log("Populating STORE entries");
+  for (const store of TEST_STORES) {
+    await firestore.collection(STORES_COLLECTION).add(store);
   }
-  const curOrders = await firestore.collection(ORDERS_COLLECTION).get();
-  if (true || !curOrders.docs.length) {
-    console.log("Populating ORDER entries");
-    for (const order of TEST_ORDERS) {
-      await firestore.collection(ORDERS_COLLECTION).add(order);
-    }
+  console.log("Populating ORDER entries");
+  for (const order of TEST_ORDERS) {
+    await firestore.collection(ORDERS_COLLECTION).add(order);
   }
 };
 

--- a/server/emulatedFirestore.js
+++ b/server/emulatedFirestore.js
@@ -26,20 +26,35 @@ const setupSimulatedDB = async () => {
   console.log("setting up emulation firestore");
 
   // Add our dummy data into emulated firestore
-  for (const user of TEST_USERS) {
-    await firestore.collection(USERS_COLLECTION).add(user);
+  const curUsers = await firestore.collection(USERS_COLLECTION).get();
+  if (true || !curUsers.docs.length) {
+    console.log("Populating USER entries");
+    for (const user of TEST_USERS) {
+      await firestore.collection(USERS_COLLECTION).add(user);
+    }
   }
-  for (const item of TEST_ITEMS) {
-    await firestore.collection(ITEMS_COLLECTION).add(item);
+  const curItems = await firestore.collection(ITEMS_COLLECTION).get();
+  if (true || !curItems.docs.length) {
+    console.log("Populating ITEM entries");
+    for (const item of TEST_ITEMS) {
+      await firestore.collection(ITEMS_COLLECTION).add(item);
+    }
   }
-  for (const store of TEST_STORES) {
-    await firestore.collection(STORES_COLLECTION).add(store);
+  const curStores = await firestore.collection(STORES_COLLECTION).get();
+  if (true || !curStores.docs.length) {
+    console.log("Populating STORE entries");
+    for (const store of TEST_STORES) {
+      await firestore.collection(STORES_COLLECTION).add(store);
+    }
   }
-  for (const order of TEST_ORDERS) {
-    await firestore.collection(ORDERS_COLLECTION).add(order);
+  const curOrders = await firestore.collection(ORDERS_COLLECTION).get();
+  if (true || !curOrders.docs.length) {
+    console.log("Populating ORDER entries");
+    for (const order of TEST_ORDERS) {
+      await firestore.collection(ORDERS_COLLECTION).add(order);
+    }
   }
 };
 
-setupSimulatedDB();
-
-module.exports = firestore;
+module.exports.firestore = firestore;
+module.exports.populate = setupSimulatedDB;

--- a/server/firestore.js
+++ b/server/firestore.js
@@ -6,7 +6,7 @@ const { ENV, TEST } = require("./config");
 //            initializing it in a separate script
 // Live:      Initialize Server <-> Live DB communication
 const firestore =
-  ENV === TEST ? require("./emulatedFirestore") : new Firestore();
+  ENV === TEST ? require("./emulatedFirestore").firestore : new Firestore();
 // Note:  The interface declared in @firebase/testing and
 //        @google-cloud/firestore matches when we run our
 //        emulated database with:

--- a/server/globalTestSetup.js
+++ b/server/globalTestSetup.js
@@ -1,0 +1,5 @@
+const { populate } = require("./emulatedFirestore");
+
+module.exports = async () => {
+  await populate();
+};

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "start": "NODE_ENV=\"production\" node server.js",
     "pretest": "curl -X DELETE \"http://localhost:8080/emulator/v1/projects/scan-and-go-for-gpay/databases/(default)/documents\"",
     "test": "NODE_ENV=\"test\" jest",
+    "prestart_test": "curl -X DELETE \"http://localhost:8080/emulator/v1/projects/scan-and-go-for-gpay/databases/(default)/documents\"",
     "start_test": "NODE_ENV=\"test\" node server.js"
   },
   "eslintConfig": {
@@ -16,6 +17,7 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "globalSetup": "<rootDir>/globalTestSetup.js",
     "coveragePathIgnorePatterns": [
       "/node_modules/"
     ]

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ const helmet = require("helmet");
 const cors = require("cors");
 const apiRouter = require("./routers/api-router");
 const config = require("./config");
+const { populate } = require("./emulatedFirestore.js");
 
 const app = express();
 
@@ -37,6 +38,11 @@ app.use((err, req, res, next) => {
 app.use(compression());
 
 const server = app.listen(PORT, function () {
+  console.log(config.ENV);
+  if (config.ENV === config.TEST) {
+    console.log("Populating emulated Firestore with entries");
+    populate();
+  }
   console.log(`Server running on: ${PORT}`);
 });
 

--- a/server/tests/DB.test.js
+++ b/server/tests/DB.test.js
@@ -1,0 +1,35 @@
+const {
+  usersCollection,
+  itemsCollection,
+  storesCollection,
+  ordersCollection,
+} = require("./../firestore");
+const { sortUsers, sortItems, sortStores, sortOrders } = require("./testUtils");
+const TEST_USERS = require("./../data/users.json").sort(sortUsers);
+const TEST_ITEMS = require("./../data/items.json").sort(sortItems);
+const TEST_STORES = require("./../data/stores.json").sort(sortStores);
+const TEST_ORDERS = require("./../data/orders.json").sort(sortOrders);
+const CONSTANTS = require("./../constants");
+
+describe("Assert Mock Database Loaded", () => {
+  it("Users database should match", async () => {
+    const usersQuery = await usersCollection.get();
+    const users = usersQuery.docs.map((doc) => doc.data()).sort(sortUsers);
+    expect(users).toEqual(TEST_USERS);
+  });
+  it("Items database should match", async () => {
+    const itemsQuery = await itemsCollection.get();
+    const items = itemsQuery.docs.map((doc) => doc.data()).sort(sortItems);
+    expect(items).toEqual(TEST_ITEMS);
+  });
+  it("Stores database should match", async () => {
+    const storesQuery = await storesCollection.get();
+    const stores = storesQuery.docs.map((doc) => doc.data()).sort(sortStores);
+    expect(stores).toEqual(TEST_STORES);
+  });
+  it("Orders database should match", async () => {
+    const ordersQuery = await ordersCollection.get();
+    const orders = ordersQuery.docs.map((doc) => doc.data()).sort(sortOrders);
+    expect(orders).toEqual(TEST_ORDERS);
+  });
+});

--- a/server/tests/routes.test.js
+++ b/server/tests/routes.test.js
@@ -1,10 +1,10 @@
 const request = require("supertest");
 const { app, server } = require("./../server");
-const CONSTANTS = require("./../constants");
 const TEST_USERS = require("./../data/users.json");
 const TEST_ITEMS = require("./../data/items.json");
 const TEST_STORES = require("./../data/stores.json");
 const TEST_ORDERS = require("./../data/orders.json");
+const CONSTANTS = require("./../constants");
 
 describe("API POST Data", () => {
   it("should get TEST_USER details", async () => {

--- a/server/tests/testUtils.js
+++ b/server/tests/testUtils.js
@@ -1,0 +1,18 @@
+module.exports.sortUsers = (a, b) => {
+  return a["user-id"] < b["user-id"];
+};
+
+module.exports.sortItems = (a, b) => {
+  if (a["barcode"] === b["barcode"]) {
+    return a["merchant-id"] < b["merchant-id"];
+  }
+  return a["barcode"] < b["barcode"];
+};
+
+module.exports.sortStores = (a, b) => {
+  return a["store-id"] < b["store-id"];
+};
+
+module.exports.sortOrders = (a, b) => {
+  return a["order-id"] < b["order-id"];
+};


### PR DESCRIPTION
- Fixed duplicated DB entries when running emulator for testing by placing DB initialization function to run in `globalTestSetup.js` and setting jest: `"globalSetup"` config to point to this script. Waits synchronously for setup function to complete prior to running tests.
- Fixed bug in `orders-controller` preventing successful GET of user orders which was correctly captured by the failed test in `routes.test.js` :)
- Added sanity check test to ensure all testing entries have been successfully populated in the emulated DB
- Fix introduced known issue #100