### PR TITLE
Refactored Home and StoreList into multiple smaller components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,17 +5,21 @@ import Home from "src/pages/Home";
 import ScanStore from "src/pages/ScanStore";
 import Receipt from "src/pages/Receipt";
 import NotFound from "src/pages/NotFound";
+import AppTheme from "src/theme";
+import { ThemeProvider } from "@material-ui/core/styles";
 
 function App() {
   return (
     <main>
-      <Switch>
-        <Route path="/" component={Login} exact />
-        <Route path="/home" component={Home} />
-        <Route path="/store" component={ScanStore} />
-        <Route path="/receipt" component={Receipt} />
-        <Route component={NotFound} />
-      </Switch>
+      <ThemeProvider theme={AppTheme}>
+        <Switch>
+          <Route path="/" component={Login} exact />
+          <Route path="/home" component={Home} />
+          <Route path="/store" component={ScanStore} />
+          <Route path="/receipt" component={Receipt} />
+          <Route component={NotFound} />
+        </Switch>
+      </ThemeProvider>
     </main>
   );
 }

--- a/client/src/components/StoreCard/StoreCard.tsx
+++ b/client/src/components/StoreCard/StoreCard.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { Store } from "src/interfaces";
+import { GEO_PRECISION_DIGITS } from "src/constants";
+import { Box, Typography, Paper, Card, Grid, Divider } from "@material-ui/core";
+import { useTheme } from "@material-ui/core/styles";
+
+function StoreCard({
+  store,
+  redirect,
+}: {
+  store: Store;
+  redirect: (url: string) => void;
+}) {
+  // Grab the globally-defined AppTheme via useTheme hook
+  const theme = useTheme();
+  // .spacing([1...4]) retrieves 4 non-zero preset spacing
+  const themeSpacing = theme.spacing(1);
+
+  const redirectWrapper = () => {
+    redirect("?id=" + store["store-id"] + "&mid=" + store["merchant-id"]);
+  };
+
+  return (
+    <Card
+      onClick={redirectWrapper}
+      style={{
+        cursor: "pointer",
+        marginTop: themeSpacing,
+        padding: themeSpacing,
+      }}
+    >
+      <Grid
+        container
+        direction="row"
+        justify="space-between"
+        alignItems="center"
+      >
+        <Grid item xs={4}>
+          Media
+        </Grid>
+        <Grid item xs={8}>
+          <Typography variant="subtitle1">
+            <Box display="inline" fontWeight="fontWeightBold">
+              {store.name}
+            </Box>
+          </Typography>
+          <Typography variant="body1">
+            [{store.latitude.toFixed(GEO_PRECISION_DIGITS)},
+            {store.longitude.toFixed(GEO_PRECISION_DIGITS)}]
+          </Typography>
+          <Typography variant="body2" align="right">
+            <Box display="inline" fontWeight="fontWeightBold">
+              Schrödinger's Store
+            </Box>
+          </Typography>
+        </Grid>
+      </Grid>
+    </Card>
+  );
+}
+
+export default StoreCard;

--- a/client/src/components/StoreCard/index.tsx
+++ b/client/src/components/StoreCard/index.tsx
@@ -1,0 +1,2 @@
+import StoreCard from "./StoreCard";
+export default StoreCard;

--- a/client/src/components/StoreList/StoreList.tsx
+++ b/client/src/components/StoreList/StoreList.tsx
@@ -1,244 +1,34 @@
 import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import {
-  Store,
-  IdentityToken,
-  emptyIdentityToken,
-  GMapPlace,
-  MediaResponse,
-  emptyMediaResponse,
-} from "src/interfaces";
-import { fetchJson, extractIdentityToken } from "src/utils";
-import {
-  SCANSTORE_PAGE,
-  STORE_LIST_API,
-  PLACES_RADIUS_METERS,
-  PLACES_TYPES,
-  TEST_STORE_ID,
-  TEST_STORE_MERCHANT_ID,
-} from "src/constants";
-import { microapps, google, isWeb } from "src/config";
-import Divider from "@material-ui/core/Divider";
-import { BrowserMultiFormatReader } from "@zxing/library";
-import SampleStoreQR from "src/img/Sample_StoreQR.png";
-declare const window: any;
+import { Store } from "src/interfaces";
+import { Container, Divider } from "@material-ui/core";
+import StoreCard from "src/components/StoreCard";
+import { SCANSTORE_PAGE } from "src/constants";
 
-function StoreList() {
+function StoreList({ stores }: { stores: Store[] }) {
   const history = useHistory();
 
-  const [userCoords, setUserCoords] = useState<[number, number]>([0.0, 0.0]);
-  const [storeList, setStoreList] = useState<Store[]>([]);
-  const [identity, setIdentity] = useState<IdentityToken>(emptyIdentityToken());
-  const [nearbyPlaces, setNearbyPlaces] = useState<GMapPlace[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [uploadImg, setUploadImg] = useState<MediaResponse>(
-    emptyMediaResponse()
-  );
-
-  const debugImgId = "sampleStoreQRImgSrc";
-  const uploadImgId = "storeQRImgSrc";
-
-  // Dummy map attachment
-  const map = new google.maps.Map(document.getElementById("mapPlaceholder"));
-  // Declare our Google Map/Places API service handler
-  const service = new google.maps.places.PlacesService(map);
-
-  // Error callback for location API call
-  const errorbackLoc = (error: any) => {
-    alert(error);
+  const enterStore = (url: string) => {
+    history.push({
+      pathname: SCANSTORE_PAGE,
+      search: url,
+      state: {
+        stores: stores,
+      },
+    });
   };
-
-  // Grab the location of device
-  const grabLoc = () => {
-    // Use browser navigator if we are in web environment & available
-    if (isWeb) {
-      if (navigator.geolocation) {
-        setIsLoading(true);
-        navigator.geolocation.getCurrentPosition(fetchStores, errorbackLoc);
-      }
-    } else {
-      setIsLoading(true);
-      microapps
-        .getCurrentLocation()
-        .then((loc: any) => {
-          const position = {
-            coords: {
-              latitude: loc["latitude"],
-              longitude: loc["longitude"],
-            },
-          };
-          fetchStores(position);
-        })
-        .catch((err: any) => errorbackLoc(err));
-    }
-  };
-
-  // fetch list of users
-  const fetchStores = async (position: {
-    coords: {
-      latitude: number;
-      longitude: number;
-    };
-  }) => {
-    // Update location
-    const data = {
-      distance: 10000,
-      latitude: position.coords.latitude,
-      longitude: position.coords.longitude,
-    };
-    const stores = await fetchJson("POST", data, STORE_LIST_API);
-    setUserCoords([position.coords.latitude, position.coords.longitude]);
-    setStoreList(stores);
-    setIsLoading(false);
-  };
-
-  // Request PlacesAPI for nearby locations
-  const getNearbyPlaces = () => {
-    const curLoc = new google.maps.LatLng(userCoords[0], userCoords[1]);
-    const request = {
-      location: curLoc,
-      radius: PLACES_RADIUS_METERS,
-      type: PLACES_TYPES,
-    };
-    setIsLoading(true);
-    service.nearbySearch(request, getNearbyPlacesCallback);
-  };
-
-  // Digest PlacesAPI results
-  const getNearbyPlacesCallback = (places: any, status: any) => {
-    if (status === google.maps.places.PlacesServiceStatus.OK) {
-      setNearbyPlaces(places);
-    } else {
-      alert("PlacesAPI failure to return");
-    }
-    setIsLoading(false);
-  };
-
-  // Get user identity details
-  const loginUser = async () => {
-    // Only run in iframe (on app)
-    if (!isWeb) {
-      const request = { nonce: "Don't Hack me please" };
-      microapps.getIdentity(request).then((response: any) => {
-        setIdentity(extractIdentityToken(response));
-      });
-    }
-  };
-
-  // Scan Store's QR code
-  const storeQR = async () => {
-    if (isWeb) {
-      const img = document.getElementById(debugImgId) as HTMLImageElement;
-      processImageBarcode(img);
-    } else {
-      const imgReq = {
-        allowedMimeTypes: ["image/jpeg"],
-        allowedSources: ["camera"], // Restrict to camera scanning only
-      };
-      const imgRes = await window.microapps.requestMedia(imgReq);
-      setUploadImg(imgRes);
-    }
-  };
-
-  const processImageBarcode = async (img: HTMLImageElement) => {
-    const codeReader = new BrowserMultiFormatReader();
-    if (img) {
-      const result = await codeReader
-        .decodeFromImage(img)
-        .then((res: any) => res.text);
-      if (result) {
-        history.push(SCANSTORE_PAGE + "?" + result);
-      } else {
-        //TODO(#65) Render failure message
-      }
-    }
-  };
-
-  useEffect(() => {
-    if (uploadImg.mimeType) {
-      const img = document.getElementById(uploadImgId) as HTMLImageElement;
-      processImageBarcode(img);
-    }
-  }, [uploadImg]);
 
   return (
-    <div className="StoreList">
-      {uploadImg.mimeType && (
-        <img
-          hidden={true}
-          id={uploadImgId}
-          src={"data:" + uploadImg.mimeType + ";base64," + uploadImg.bytes}
-        />
-      )}
-      <img hidden={true} id={debugImgId} src={SampleStoreQR} />
-      <h3>
-        [{userCoords[0]},{userCoords[1]}]
-      </h3>
-      <h4>
-        {identity.sub} [{isLoading ? "Loading..." : ""}]
-      </h4>
-      <button>
-        <a href={`/store?id=${TEST_STORE_ID}&mid=${TEST_STORE_MERCHANT_ID}`}>
-          Test Store
-        </a>
-      </button>
-      <button onClick={loginUser}>User Login</button>
-      <button onClick={storeQR}>Scan Store QR</button>
-      <button onClick={grabLoc}>Nearby Stores</button>
-      <button onClick={getNearbyPlaces}>Nearby Restaurants</button>
-      {storeList.length > 0 && (
-        <table>
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Distance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {storeList.map((store: Store) => (
-              <tr key={store["store-id"]}>
-                <td>{store["store-id"]}</td>
-                <td>
-                  <a
-                    href={
-                      "/store?id=" +
-                      store["store-id"] +
-                      "&mid=" +
-                      store["merchant-id"]
-                    }
-                  >
-                    {store.name}
-                  </a>
-                </td>
-                <td>{store.distance}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-      <Divider />
-      {nearbyPlaces.length > 0 && (
-        <table>
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Name</th>
-              <th>Address</th>
-            </tr>
-          </thead>
-          <tbody>
-            {nearbyPlaces.map((place: GMapPlace) => (
-              <tr key={place["place_id"]}>
-                <td>{place["place_id"]}</td>
-                <td>{place.name}</td>
-                <td>{place.vicinity}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
+    <Container disableGutters={true} className="StoreList">
+      {stores &&
+        stores.map((store) => (
+          <StoreCard
+            key={store["store-id"]}
+            redirect={enterStore}
+            store={store}
+          />
+        ))}
+    </Container>
   );
 }
 

--- a/client/src/components/UserHeader/UserHeader.tsx
+++ b/client/src/components/UserHeader/UserHeader.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+import { User } from "src/interfaces";
+import { DEFAULT_WELCOME_MSG } from "src/constants";
+import { Typography, Paper, Grid, Box, Button } from "@material-ui/core";
+import { getDayPeriod } from "src/utils";
+
+function UserHeader({ user }: { user: User | null }) {
+  const curHour = new Date().getHours();
+  const curMin = new Date().getMinutes();
+  const [curSec, setCurSec] = useState();
+
+  const updateTime = () => {
+    setCurSec(new Date().getSeconds());
+  };
+
+  const padTime = (num: number) => {
+    // Ensure our time is output in hh:mm:ss
+    // non-constants used will unlikely change
+    return num ? num.toString().padStart(2, "0") : "";
+  };
+
+  useEffect(() => {
+    updateTime();
+  }, []);
+
+  useEffect(() => {
+    // Register time watching
+    setInterval(updateTime, 500);
+  }, [curSec]);
+
+  return (
+    <div className="UserHeader">
+      {user && (
+        <Paper elevation={0}>
+          <Grid container direction="row" justify="space-between">
+            <Grid item xs={8}>
+              <Grid item xs={12}>
+                <Typography variant="h4">
+                  Good {getDayPeriod()}{" "}
+                  <Box display="inline" fontWeight="fontWeightBold">
+                    {user.name}
+                  </Box>
+                  !
+                </Typography>
+              </Grid>
+              <Grid item xs={12}>
+                <Typography variant="body1">
+                  {padTime(curHour)}:{padTime(curMin)}:{padTime(curSec)}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Grid item xs={3}>
+              <Button fullWidth={true} variant="contained" color="primary">
+                Shopping List
+              </Button>
+            </Grid>
+          </Grid>
+        </Paper>
+      )}
+    </div>
+  );
+}
+
+export default UserHeader;

--- a/client/src/components/UserHeader/index.tsx
+++ b/client/src/components/UserHeader/index.tsx
@@ -1,0 +1,2 @@
+import UserHeader from "./UserHeader";
+export default UserHeader;

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,7 +1,5 @@
 declare const window: any;
 
-export const isDebug = false;
-
 // Grab a handle to our microapps javascript library
 export const microapps = window.microapps;
 
@@ -13,3 +11,6 @@ export const google = window.google;
 // reference itself. However, within the microapps environment
 // window will be the iframe and window.parent will not be visible
 export const isWeb = window === window.parent;
+
+// Enable debugging on web by default
+export const isDebug = false || isWeb;

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -26,8 +26,17 @@ export const DEFAULT_WELCOME_MSG = "hello";
 export const DEFAULT_USERNAME = "commander";
 export const DEFAULT_BACK_BTN_TEXT = "back";
 export const PRICE_FRACTION_DIGITS = 2;
+export const GEO_PRECISION_DIGITS = 7;
 export const PLACES_RADIUS_METERS = "5000";
 export const PLACES_TYPES = ["restaurant"];
 // Test variables
 export const TEST_STORE_ID = "WPANCUD-1";
 export const TEST_STORE_MERCHANT_ID = "WPANCUD";
+// Enums
+export enum DAY_PERIOD {
+  MORNING = "Morning",
+  NOON = "Noon",
+  AFTERNOON = "Afternoon",
+  EVENING = "Evening",
+  NIGHT = "Night",
+}

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -26,7 +26,7 @@ export const DEFAULT_WELCOME_MSG = "hello";
 export const DEFAULT_USERNAME = "commander";
 export const DEFAULT_BACK_BTN_TEXT = "back";
 export const PRICE_FRACTION_DIGITS = 2;
-export const GEO_PRECISION_DIGITS = 7;
+export const GEO_PRECISION_DIGITS = 3;
 export const PLACES_RADIUS_METERS = "5000";
 export const PLACES_TYPES = ["restaurant"];
 // Test variables

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -53,6 +53,7 @@ export const emptyStore = (): Store => ({
 export interface IdentityToken {
   iss: string; // Issuer identifier (accounts.google.com)
   sub: string; // Unique identifier tied to Google account
+  name: string; // User's displayed name
   aud: string; // Audience: OAuth2.0 client ID of our GCP Project
   iat: number; // Token validity start time
   exp: number; // Token validity expiry time
@@ -61,9 +62,20 @@ export interface IdentityToken {
 export const emptyIdentityToken = (): IdentityToken => ({
   iss: "",
   sub: "EMPTY",
+  name: "",
   aud: "",
   iat: -1,
   exp: 0,
+});
+
+export interface User {
+  name: string;
+  "user-id": string;
+}
+
+export const emptyUser = (): User => ({
+  name: "",
+  "user-id": "",
 });
 
 // results json response from PlacesAPI call:

--- a/client/src/pages/Actions.ts
+++ b/client/src/pages/Actions.ts
@@ -1,10 +1,32 @@
-import { STORE_API } from "src/constants";
-import { fetchJson } from "src/utils";
-import { Store } from "src/interfaces";
+import { STORE_API, USER_API } from "src/constants";
+import { fetchJson, extractIdentityToken } from "src/utils";
+import { isWeb, microapps } from "src/config";
+import { IdentityToken } from "src/interfaces";
 
 export const getStoreInfo = async (storeId: string) => {
   const data = {
     "store-id": storeId,
   };
   return await fetchJson("POST", data, STORE_API);
+};
+
+export const getUserInfo = async (userId: string) => {
+  const data = {
+    "user-id": userId,
+  };
+  return await fetchJson("POST", data, USER_API);
+};
+
+export const loginUser = (): IdentityToken | null => {
+  if (isWeb) {
+    return null;
+  }
+  const request = { nonce: "Don't Hack me please" };
+  const identityToken = microapps
+    .getIdentity(request)
+    .then((res: any) => extractIdentityToken(res))
+    .catch((err: any) => {
+      return null;
+    });
+  return identityToken;
 };

--- a/client/src/pages/Home/DebugBar.tsx
+++ b/client/src/pages/Home/DebugBar.tsx
@@ -26,11 +26,14 @@ import { BrowserMultiFormatReader } from "@zxing/library";
 import SampleStoreQR from "src/img/Sample_StoreQR.png";
 declare const window: any;
 
-function DebugBar() {
+function DebugBar({
+  storesCallback,
+}: {
+  storesCallback: (stores: Store[]) => void;
+}) {
   const history = useHistory();
 
   const [userCoords, setUserCoords] = useState<[number, number]>([0.0, 0.0]);
-  const [storeList, setStoreList] = useState<Store[]>([]);
   const [identity, setIdentity] = useState<IdentityToken>(emptyIdentityToken());
   const [nearbyPlaces, setNearbyPlaces] = useState<GMapPlace[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -91,7 +94,7 @@ function DebugBar() {
     };
     const stores = await fetchJson("POST", data, STORE_LIST_API);
     setUserCoords([position.coords.latitude, position.coords.longitude]);
-    setStoreList(stores);
+    storesCallback(stores);
     setIsLoading(false);
   };
 
@@ -188,7 +191,6 @@ function DebugBar() {
         {userCoords[1].toFixed(GEO_PRECISION_DIGITS)}] | {identity.sub} [
         {isLoading ? "Loading..." : ""}]
       </h3>
-      <StoreList stores={storeList} />
     </div>
   );
 }

--- a/client/src/pages/Home/DebugBar.tsx
+++ b/client/src/pages/Home/DebugBar.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from "react";
+import { useHistory } from "react-router-dom";
+import TextInputField from "src/components/TextInputField";
+import StoreList from "src/components/StoreList";
+import { fetchJson, extractIdentityToken } from "src/utils";
+import { microapps, google, isWeb } from "src/config";
+import {
+  Store,
+  emptyStore,
+  MediaResponse,
+  emptyMediaResponse,
+  IdentityToken,
+  emptyIdentityToken,
+  GMapPlace,
+} from "src/interfaces";
+import {
+  TEST_STORE_ID,
+  TEST_STORE_MERCHANT_ID,
+  SCANSTORE_PAGE,
+  STORE_LIST_API,
+  PLACES_RADIUS_METERS,
+  PLACES_TYPES,
+  GEO_PRECISION_DIGITS,
+} from "src/constants";
+import { BrowserMultiFormatReader } from "@zxing/library";
+import SampleStoreQR from "src/img/Sample_StoreQR.png";
+declare const window: any;
+
+function DebugBar() {
+  const history = useHistory();
+
+  const [userCoords, setUserCoords] = useState<[number, number]>([0.0, 0.0]);
+  const [storeList, setStoreList] = useState<Store[]>([]);
+  const [identity, setIdentity] = useState<IdentityToken>(emptyIdentityToken());
+  const [nearbyPlaces, setNearbyPlaces] = useState<GMapPlace[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [uploadImg, setUploadImg] = useState<MediaResponse>(
+    emptyMediaResponse()
+  );
+
+  const debugImgId = "sampleStoreQRImgSrc";
+  const uploadImgId = "storeQRImgSrc";
+
+  // Dummy map attachment
+  const map = new google.maps.Map(document.getElementById("mapPlaceholder"));
+  // Declare our Google Map/Places API service handler
+  const service = new google.maps.places.PlacesService(map);
+
+  // Error callback for location API call
+  const errorbackLoc = (error: any) => {
+    alert(error);
+  };
+
+  // Grab the location of device
+  const grabLoc = () => {
+    // Use browser navigator if we are in web environment & available
+    if (isWeb) {
+      if (navigator.geolocation) {
+        setIsLoading(true);
+        navigator.geolocation.getCurrentPosition(fetchStores, errorbackLoc);
+      }
+    } else {
+      setIsLoading(true);
+      microapps
+        .getCurrentLocation()
+        .then((loc: any) => {
+          const position = {
+            coords: {
+              latitude: loc["latitude"],
+              longitude: loc["longitude"],
+            },
+          };
+          fetchStores(position);
+        })
+        .catch((err: any) => errorbackLoc(err));
+    }
+  };
+
+  // fetch list of users
+  const fetchStores = async (position: {
+    coords: {
+      latitude: number;
+      longitude: number;
+    };
+  }) => {
+    // Update location
+    const data = {
+      distance: 10000,
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+    };
+    const stores = await fetchJson("POST", data, STORE_LIST_API);
+    setUserCoords([position.coords.latitude, position.coords.longitude]);
+    setStoreList(stores);
+    setIsLoading(false);
+  };
+
+  // Request PlacesAPI for nearby locations
+  const getNearbyPlaces = () => {
+    const curLoc = new google.maps.LatLng(userCoords[0], userCoords[1]);
+    const request = {
+      location: curLoc,
+      radius: PLACES_RADIUS_METERS,
+      type: PLACES_TYPES,
+    };
+    setIsLoading(true);
+    service.nearbySearch(request, getNearbyPlacesCallback);
+  };
+
+  // Digest PlacesAPI results
+  const getNearbyPlacesCallback = (places: any, status: any) => {
+    if (status === google.maps.places.PlacesServiceStatus.OK) {
+      setNearbyPlaces(places);
+    } else {
+      alert("PlacesAPI failure to return");
+    }
+    setIsLoading(false);
+  };
+
+  // Get user identity details
+  const loginUser = async () => {
+    // Only run in iframe (on app)
+    if (!isWeb) {
+      const request = { nonce: "Don't Hack me please" };
+      microapps.getIdentity(request).then((response: any) => {
+        setIdentity(extractIdentityToken(response));
+      });
+    }
+  };
+
+  // Scan Store's QR code
+  const storeQR = async () => {
+    if (isWeb) {
+      const img = document.getElementById(debugImgId) as HTMLImageElement;
+      processImageBarcode(img);
+    } else {
+      const imgReq = {
+        allowedMimeTypes: ["image/jpeg"],
+        allowedSources: ["camera"], // Restrict to camera scanning only
+      };
+      const imgRes = await window.microapps.requestMedia(imgReq);
+      setUploadImg(imgRes);
+    }
+  };
+
+  const processImageBarcode = async (img: HTMLImageElement) => {
+    const codeReader = new BrowserMultiFormatReader();
+    if (img) {
+      const result = await codeReader
+        .decodeFromImage(img)
+        .then((res: any) => res.text);
+      if (result) {
+        history.push(SCANSTORE_PAGE + "?" + result);
+      } else {
+        //TODO(#65) Render failure message
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (uploadImg.mimeType) {
+      const img = document.getElementById(uploadImgId) as HTMLImageElement;
+      processImageBarcode(img);
+    }
+  }, [uploadImg]);
+
+  return (
+    <div className="DebugBar">
+      {uploadImg.mimeType && (
+        <img
+          hidden={true}
+          id={uploadImgId}
+          src={"data:" + uploadImg.mimeType + ";base64," + uploadImg.bytes}
+        />
+      )}
+      <img hidden={true} id={debugImgId} src={SampleStoreQR} />
+      <button>
+        <a href={`/store?id=${TEST_STORE_ID}&mid=${TEST_STORE_MERCHANT_ID}`}>
+          Test Store
+        </a>
+      </button>
+      <button onClick={loginUser}>User Login</button>
+      <button onClick={storeQR}>Scan Store QR</button>
+      <button onClick={grabLoc}>Nearby Stores</button>
+      <button onClick={getNearbyPlaces}>Nearby Restaurants</button>
+      <h3 style={{ color: "#ABABAB" }}>
+        [{userCoords[0].toFixed(GEO_PRECISION_DIGITS)},
+        {userCoords[1].toFixed(GEO_PRECISION_DIGITS)}] | {identity.sub} [
+        {isLoading ? "Loading..." : ""}]
+      </h3>
+      <StoreList stores={storeList} />
+    </div>
+  );
+}
+
+export default DebugBar;

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,79 +1,41 @@
 import React, { useEffect, useState } from "react";
+import { withRouter } from "react-router-dom";
 import StoreList from "src/components/StoreList";
 import TextInputField from "src/components/TextInputField";
-import { fetchJson, fetchText } from "src/utils";
-import {
-  Container,
-  Table,
-  TableBody,
-  TableHead,
-  TableRow,
-  TableCell,
-} from "@material-ui/core";
-import { API, USER_LIST_API, DEFAULT_WELCOME_MSG } from "src/constants";
+import UserHeader from "src/components/UserHeader";
+import DebugBar from "./DebugBar";
+import { User, emptyUser, Store } from "src/interfaces";
+import { getUserInfo } from "src/pages/Actions";
+import { Container } from "@material-ui/core";
 import { isDebug } from "src/config";
 
-// Testing code, will be removed soon
-interface UserUI {
-  "user-id": string;
-  name: string;
-}
-
-function Home() {
-  const [welMsg, setWelMsg] = useState("");
+function Home(props: any) {
   const [userid, setUserid] = useState("");
-  const [usersList, setUsersList] = useState<UserUI[]>([]);
+  const [curUser, setCurUser] = useState<User>(emptyUser());
+  const [stores, setStores] = useState<Store[]>([]);
 
   useEffect(() => {
-    // fetch POST welcome message
-    const fetchMsg = async () => {
-      const data = {
-        "user-id": userid,
-      };
-      let msg = await fetchText("POST", data, API);
-      if (!msg) {
-        msg = DEFAULT_WELCOME_MSG;
-      }
-      setWelMsg(msg);
-    };
+    // Initially set user based on passed props
+    if (props.location.state) {
+      setCurUser(props.location.state.user);
+      setStores(props.location.state.stores);
+    }
+  }, []);
 
-    fetchMsg();
+  useEffect(() => {
+    if (userid) {
+      getUserInfo(userid).then((res) => setCurUser(res));
+    }
   }, [userid]);
 
-  // Wrapper to issue fetch GET to /api/users/all
-  const fetchUsers = async () => {
-    const users = await fetchJson("GET", null, USER_LIST_API);
-    setUsersList(users);
-  };
-
   return (
-    <Container disableGutters={true} className="Home">
-      {isDebug && [
-        <p>{welMsg}</p>,
-        <TextInputField text={userid} setState={setUserid} />,
-        <button onClick={fetchUsers}>Fetch Users</button>,
-      ]}
-      {isDebug && usersList.length > 0 && (
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>ID</TableCell>
-              <TableCell>Name</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {usersList.map((user: UserUI) => (
-              <TableRow key={user["user-id"]}>
-                <TableCell>{user["user-id"]}</TableCell>
-                <TableCell>{user.name}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      )}
-      <StoreList />
+    <Container disableGutters={false} className="Home">
+      {isDebug && <TextInputField text={userid} setState={setUserid} />}
+      <UserHeader user={curUser} />
+      <DebugBar />
+      <StoreList stores={stores} />
     </Container>
   );
 }
 
-export default Home;
+export default withRouter(Home);

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -32,7 +32,7 @@ function Home(props: any) {
     <Container disableGutters={false} className="Home">
       {isDebug && <TextInputField text={userid} setState={setUserid} />}
       <UserHeader user={curUser} />
-      <DebugBar />
+      {isDebug && <DebugBar storesCallback={setStores} />}
       <StoreList stores={stores} />
     </Container>
   );

--- a/client/src/pages/Login/Login.test.tsx
+++ b/client/src/pages/Login/Login.test.tsx
@@ -31,7 +31,8 @@ describe("Test on Web UI", () => {
     const mountedWrapper = Enzyme.mount(<Login />);
     const input = mountedWrapper.find("#username").last();
     input.simulate("blur", { target: { value: validUser } });
-    expect(global.mockRedirectPush).toBeCalledWith("/home");
+    const pushArgs = global.mockRedirectPush.mock.calls[0];
+    expect(pushArgs[0]).toHaveProperty("pathname", "/home");
   });
 });
 
@@ -62,8 +63,9 @@ describe("Simulate test within GPay Env", () => {
     expect(microappsIdentityAPI).toHaveBeenCalledTimes(1);
     // After Login is called and we sent over a valid identity
     // we should expect a url redirect
-    await waitFor(() =>
-      expect(global.mockRedirectPush).toBeCalledWith("/home")
-    );
+    await waitFor(() => {
+      const pushArgs = global.mockRedirectPush.mock.calls[0];
+      expect(pushArgs[0]).toHaveProperty("pathname", "/home");
+    });
   });
 });

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import TextInputField from "src/components/TextInputField";
 import { Container, Grid, Typography, Button } from "@material-ui/core";
-import { IdentityToken, emptyIdentityToken } from "src/interfaces";
+import { User, emptyUser, IdentityToken } from "src/interfaces";
 import { extractIdentityToken } from "src/utils";
 import { HOME_PAGE, TITLE_TEXT } from "src/constants";
 import { microapps, isWeb, isDebug } from "src/config";
+import { loginUser } from "src/pages/Actions";
 import Logo from "src/img/Logo.png";
 import "src/css/Login.css";
 declare const window: any;
@@ -17,34 +18,42 @@ function Login() {
 
   // Flag for us to manually run login on mobile
   const [loginError, setLoginError] = useState(false);
-  // User Identity
-  const [identity, setIdentity] = useState<IdentityToken>(emptyIdentityToken());
+  const [user, setUser] = useState<User>(emptyUser());
 
   const updateUser = (text: string) => {
-    const newIdentity = emptyIdentityToken();
-    setIdentity(Object.assign({}, newIdentity, { sub: text }));
+    //setIdentity(Object.assign({}, emptyIdentityToken(), { sub: text }));
+    setUser(
+      Object.assign({}, emptyUser(), {
+        name: text,
+        "user-id": "TEST_WEB_USER",
+      })
+    );
   };
 
   const login = () => {
-    if (isWeb) {
-      return;
+    const decodedIdentity: IdentityToken | null = loginUser();
+    if (decodedIdentity) {
+      setUser(
+        Object.assign({}, emptyUser(), {
+          name: decodedIdentity.name,
+          "user-id": decodedIdentity.sub,
+        })
+      );
+    } else {
+      setLoginError(true);
     }
-    const request = { nonce: "Don't Hack me please" };
-    microapps
-      .getIdentity(request)
-      .then((response: any) => {
-        setIdentity(extractIdentityToken(response));
-      })
-      .catch((error: any) => {
-        setLoginError(true);
-      });
   };
 
   useEffect(() => {
-    if (identity.sub !== "EMPTY" && identity.sub !== "") {
-      history.push(HOME_PAGE);
+    if (user.name !== "EMPTY" && user.name !== "") {
+      history.push({
+        pathname: HOME_PAGE,
+        state: {
+          user: user,
+        },
+      });
     }
-  }, [identity]);
+  }, [user]);
 
   useEffect(() => {
     // Initial login if on microapp

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,0 +1,18 @@
+import { createMuiTheme } from "@material-ui/core/styles";
+
+// https://material-ui.com/customization/theming/#createmuitheme-options-args-theme
+// Customize our app-specific theme
+const AppTheme = createMuiTheme({
+  palette: {
+    primary: {
+      main: "#66BE64",
+      contrastText: "white",
+    },
+    secondary: {
+      main: "#909090",
+      contrastText: "white",
+    },
+  },
+});
+
+export default AppTheme;

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,3 +1,5 @@
+import { DAY_PERIOD } from "src/constants";
+
 // Get json from response
 const getJson = (res: any) => {
   if (res.ok) {
@@ -60,7 +62,7 @@ export const fetchText = async (reqType: string, data: any, url: string) => {
 };
 
 // Extract Identity Token from getIdentity() call response
-export const extractIdentityToken = (response: any) => {
+export const extractIdentityToken = (response: string) => {
   // Token response is base64 encoded from getIdentity() API call
   // Furthermore, it is split into period-separated sections
   // [0] describes the encryption scheme used
@@ -82,5 +84,28 @@ export const urlGetJson = (param: string) => {
     if (decodedJsonString) {
       return JSON.parse(decodedJsonString);
     }
+  }
+};
+
+// Grab the current period of day for user
+export const getDayPeriod = () => {
+  const NIGHT_LIM = 5;
+  const MORNING_LIM = 11;
+  const NOON_LIM = 13;
+  const AFTERNOON_LIM = 18;
+  const EVENING_LIM = 22;
+  const curHour = new Date().getHours();
+  if (curHour < NIGHT_LIM) {
+    return DAY_PERIOD.NIGHT;
+  } else if (curHour < MORNING_LIM) {
+    return DAY_PERIOD.MORNING;
+  } else if (curHour < NOON_LIM) {
+    return DAY_PERIOD.NOON;
+  } else if (curHour < AFTERNOON_LIM) {
+    return DAY_PERIOD.AFTERNOON;
+  } else if (curHour < EVENING_LIM) {
+    return DAY_PERIOD.EVENING;
+  } else {
+    return DAY_PERIOD.NIGHT;
   }
 };


### PR DESCRIPTION
- Broke down `StoreList` into:
  - `pages/Home/DebugBar`
  - `components/StoreCard`
  - `components/UserHeader`
  - Moved api calls into `Home` & `DebugBar`
    - We should not have api calls within `components/*`
- Added `theme.ts` to use @material-ui/core/styles for consistent styling
- Added `UserHeader` to display user information
- Further abstracted extracting user info logic from Login into `Actions.ts` as this would also be used in subsequent pages
- [In Progress] DebugBar still contains many logical functions that can be abstracted into `pages/Actions.ts`
- [~~In Progress~~ Resolved] Migrated to passing of props via `history().push({pathname: "url", state: props})` which breaks current tests watching for redirect links passed as `push("url")`

For clarity:
![Screenshot 2020-06-23 at 17 14 13](https://user-images.githubusercontent.com/5269791/85385537-fdf8db80-b574-11ea-916e-cb5c5458fae1.png)
**DebugBar is the unstyled row of buttons and greyed-out text**
