### PR TITLE
Abstracted REST API requests from components into Actions.ts | Introduced transform.ts to transform between DB model and UI object as per #115

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,7 +25,7 @@
       Link to CDN for microapps.js library?
     -->
     <script src="https://microapps.google.com/apis/v1alpha/microapps.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBkGOvn8gUfLrECXPQ5KFNCHUqoXr3mzCc&libraries=places"></script>
+    <script id="mapPlacesAPIScript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBkGOvn8gUfLrECXPQ5KFNCHUqoXr3mzCc&libraries=places"></script>
     <title>ScanAndGo GPay</title>
   </head>
   <body>

--- a/client/src/components/StoreCard/StoreCard.tsx
+++ b/client/src/components/StoreCard/StoreCard.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { Store } from "src/interfaces";
 import { GEO_PRECISION_DIGITS } from "src/constants";
-import { Box, Typography, Paper, Card, Grid, Divider } from "@material-ui/core";
+import { Box, Typography, Card, Grid } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
+
+// Specific Constants for this component
+export const MAX_CARD_HEIGHT = 100;
 
 function StoreCard({
   store,
@@ -20,6 +23,8 @@ function StoreCard({
     redirect("?id=" + store["store-id"] + "&mid=" + store["merchant-id"]);
   };
 
+  console.log(store);
+
   return (
     <Card
       onClick={redirectWrapper}
@@ -36,7 +41,8 @@ function StoreCard({
         alignItems="center"
       >
         <Grid item xs={4}>
-          Media
+          {store.media && <img src={store.media} height={MAX_CARD_HEIGHT} />}
+          {!store.media && <p>Media Placeholder</p>}
         </Grid>
         <Grid item xs={8}>
           <Typography variant="subtitle1">

--- a/client/src/components/StoreCard/StoreCard.tsx
+++ b/client/src/components/StoreCard/StoreCard.tsx
@@ -23,8 +23,6 @@ function StoreCard({
     redirect("?id=" + store["store-id"] + "&mid=" + store["merchant-id"]);
   };
 
-  console.log(store);
-
   return (
     <Card
       onClick={redirectWrapper}

--- a/client/src/components/StoreList/StoreList.tsx
+++ b/client/src/components/StoreList/StoreList.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useHistory } from "react-router-dom";
 import { Store } from "src/interfaces";
-import { Container, Divider } from "@material-ui/core";
+import { Container } from "@material-ui/core";
 import StoreCard from "src/components/StoreCard";
 import { SCANSTORE_PAGE } from "src/constants";
 

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -13,4 +13,7 @@ export const google = window.google;
 export const isWeb = window === window.parent;
 
 // Enable debugging on web by default
-export const isDebug = false || isWeb;
+export const isDebug = true;
+
+// Places API Key
+export const PLACES_KEY = "AIzaSyBkGOvn8gUfLrECXPQ5KFNCHUqoXr3mzCc";

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -20,6 +20,8 @@ export const BARCODE_PLACEHOLDER = "...barcode";
 export const ID_PLACEHOLDER = "...id";
 export const EMPTY_PLACEHOLDER = "";
 export const TITLE_TEXT = "ScanAndGo";
+// HTML DOM Handles
+export const GOOGLE_MAP_PLACEHOLDER_ID = "mapPlaceholder";
 // Default values
 export const DEFAULT_INPUT_TYPE = "text";
 export const DEFAULT_WELCOME_MSG = "hello";
@@ -29,6 +31,7 @@ export const PRICE_FRACTION_DIGITS = 2;
 export const GEO_PRECISION_DIGITS = 3;
 export const PLACES_RADIUS_METERS = "5000";
 export const PLACES_TYPES = ["restaurant"];
+export const DEFAULT_STORE_RADIUS = 10000;
 // Test variables
 export const TEST_STORE_ID = "WPANCUD-1";
 export const TEST_STORE_MERCHANT_ID = "WPANCUD";

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -22,6 +22,7 @@ export const EMPTY_PLACEHOLDER = "";
 export const TITLE_TEXT = "ScanAndGo";
 // HTML DOM Handles
 export const GOOGLE_MAP_PLACEHOLDER_ID = "mapPlaceholder";
+export const GOOGLE_PLACES_SCRIPT_ID = "mapPlacesAPIScript";
 // Default values
 export const DEFAULT_INPUT_TYPE = "text";
 export const DEFAULT_WELCOME_MSG = "hello";

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -35,16 +35,18 @@ export interface Store {
   "store-id": string; // Unique store-id -> Can match GMaps place_id
   "merchant-id": string; // Merchant this store belongs to (for payment info)
   name: string; // Displayed name
-  distance: number; //TODO: Refactor this field out to keep consistency with DB
   latitude: number; // Geolocation information
   longitude: number; // ''
+  distance?: number; //TODO(#115): Refactor out UI-only fields to keep consistency with DB
+  media?: string; // Image/Icon displayed
+  business_status?: string; // State of store opening
+  vicinity?: string; // Address of store
 }
 
 export const emptyStore = (): Store => ({
   "store-id": "",
   "merchant-id": "",
   name: "",
-  distance: 0.0,
   latitude: 0.0,
   longitude: 0.0,
 });
@@ -85,10 +87,15 @@ export interface GMapPlace {
   geometry: {
     // Encodes location information for map display
     location: {
-      lat: number;
-      lng: number;
+      lat: () => number; // Note: These are functions!
+      lng: () => number; // this is not entirely clear from the Places API documentation
     };
   };
+  photos: [
+    {
+      getUrl: (params?: any) => string;
+    }
+  ];
   icon: string; // URL link to image for display
   id: string; //TODO: appears to be an internal id we may not need
   name: string; // Displayed name
@@ -104,4 +111,18 @@ export interface MediaResponse {
 export const emptyMediaResponse = (): MediaResponse => ({
   bytes: "",
   mimeType: "",
+});
+
+export interface GeoLocation {
+  coords: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+export const emptyGeoLocation = (): GeoLocation => ({
+  coords: {
+    latitude: 0.0,
+    longitude: 0.0,
+  },
 });

--- a/client/src/pages/Actions.ts
+++ b/client/src/pages/Actions.ts
@@ -2,6 +2,8 @@ import {
   STORE_API,
   STORE_LIST_API,
   USER_API,
+  ITEM_API,
+  ITEM_LIST_API,
   DEFAULT_STORE_RADIUS,
   PLACES_RADIUS_METERS,
   PLACES_TYPES,
@@ -21,6 +23,8 @@ const loadGooglePlacesService = () => {
   service = new google.maps.places.PlacesService(map);
 };
 
+// Depending on when Actions.ts is loaded, we may not have retrieved
+// google Places API Script yet. If so, watch <script> for load prior to init
 if (google) {
   loadGooglePlacesService();
 } else {
@@ -54,6 +58,20 @@ export const getUserInfo = async (userId: string) => {
     "user-id": userId,
   };
   return await fetchJson("POST", data, USER_API);
+};
+
+export const getItem = async (
+  barcode: string | null,
+  merchantId: string | null
+) => {
+  if (!barcode || !merchantId) {
+    return null;
+  }
+  const data = {
+    "merchant-id": merchantId,
+    barcode: barcode,
+  };
+  return await fetchJson("POST", data, ITEM_API);
 };
 
 export const loginUser = (): IdentityToken | null => {

--- a/client/src/pages/Actions.ts
+++ b/client/src/pages/Actions.ts
@@ -6,16 +6,29 @@ import {
   PLACES_RADIUS_METERS,
   PLACES_TYPES,
   GOOGLE_MAP_PLACEHOLDER_ID,
+  GOOGLE_PLACES_SCRIPT_ID,
 } from "src/constants";
 import { fetchJson, extractIdentityToken } from "src/utils";
 import { isWeb, google, microapps } from "src/config";
 import { IdentityToken, GeoLocation, emptyGeoLocation } from "src/interfaces";
 
 // Load up Google Maps Places API Service
-const map = new google.maps.Map(
-  document.getElementById(GOOGLE_MAP_PLACEHOLDER_ID)
-);
-const service = new google.maps.places.PlacesService(map);
+let map: any;
+let service: any;
+
+const loadGooglePlacesService = () => {
+  map = new google.maps.Map(document.getElementById(GOOGLE_MAP_PLACEHOLDER_ID));
+  service = new google.maps.places.PlacesService(map);
+};
+
+if (google) {
+  loadGooglePlacesService();
+} else {
+  const googleScript = document.getElementById(GOOGLE_PLACES_SCRIPT_ID);
+  if (googleScript) {
+    googleScript.addEventListener("load", loadGooglePlacesService);
+  }
+}
 
 export const getStoreInfo = async (storeId: string) => {
   const data = {

--- a/client/src/pages/Actions.ts
+++ b/client/src/pages/Actions.ts
@@ -1,13 +1,39 @@
-import { STORE_API, USER_API } from "src/constants";
+import {
+  STORE_API,
+  STORE_LIST_API,
+  USER_API,
+  DEFAULT_STORE_RADIUS,
+  PLACES_RADIUS_METERS,
+  PLACES_TYPES,
+  GOOGLE_MAP_PLACEHOLDER_ID,
+} from "src/constants";
 import { fetchJson, extractIdentityToken } from "src/utils";
-import { isWeb, microapps } from "src/config";
-import { IdentityToken } from "src/interfaces";
+import { isWeb, google, microapps } from "src/config";
+import { IdentityToken, GeoLocation, emptyGeoLocation } from "src/interfaces";
+
+// Load up Google Maps Places API Service
+const map = new google.maps.Map(
+  document.getElementById(GOOGLE_MAP_PLACEHOLDER_ID)
+);
+const service = new google.maps.places.PlacesService(map);
 
 export const getStoreInfo = async (storeId: string) => {
   const data = {
     "store-id": storeId,
   };
   return await fetchJson("POST", data, STORE_API);
+};
+
+export const getStoresByLocation = async (
+  position: GeoLocation,
+  distance?: number
+) => {
+  const data = {
+    distance: DEFAULT_STORE_RADIUS,
+    latitude: position.coords.latitude,
+    longitude: position.coords.longitude,
+  };
+  return await fetchJson("POST", data, STORE_LIST_API);
 };
 
 export const getUserInfo = async (userId: string) => {
@@ -21,6 +47,7 @@ export const loginUser = (): IdentityToken | null => {
   if (isWeb) {
     return null;
   }
+  //TODO(#113) Server-side generated nonce?
   const request = { nonce: "Don't Hack me please" };
   const identityToken = microapps
     .getIdentity(request)
@@ -29,4 +56,42 @@ export const loginUser = (): IdentityToken | null => {
       return null;
     });
   return identityToken;
+};
+
+export const getGeoLocation = (
+  successCallback: (position: GeoLocation) => void,
+  errorCallback?: (error: any) => void
+) => {
+  if (isWeb) {
+    // Use browser navigator
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        successCallback,
+        errorCallback ? errorCallback : () => {}
+      );
+    }
+  } else {
+    // Use microapps API
+    microapps
+      .getCurrentLocation()
+      .then((loc: any) => Object.assign(emptyGeoLocation(), { coords: loc }))
+      .then((pos: GeoLocation) => successCallback(pos))
+      .catch((err: any) => (errorCallback ? errorCallback(err) : null));
+  }
+};
+
+export const getNearbyPlacesTest = (
+  position: GeoLocation,
+  successCallback: (places: any, status: any) => void
+) => {
+  const curLoc = new google.maps.LatLng(
+    position.coords.latitude,
+    position.coords.longitude
+  );
+  const request = {
+    location: curLoc,
+    radius: PLACES_RADIUS_METERS,
+    type: PLACES_TYPES,
+  };
+  service.nearbySearch(request, successCallback);
 };

--- a/client/src/pages/Home/DebugBar.tsx
+++ b/client/src/pages/Home/DebugBar.tsx
@@ -84,7 +84,6 @@ function DebugBar({
     setIsLoading(false);
     if (status === google.maps.places.PlacesServiceStatus.OK) {
       if (placesCallback) {
-        console.log(places);
         placesCallback(places);
       }
     }
@@ -95,8 +94,6 @@ function DebugBar({
     const userToken = loginUser();
     if (userToken) {
       setIdentity(userToken);
-    } else {
-      console.error("Web Environment detected");
     }
   };
 

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -32,7 +32,6 @@ function Home(props: any) {
   }, [userid]);
 
   useEffect(() => {
-    // Transform GMapPlace into Store
     setPlaceStore(testPlaces.map((place) => transformGMapPlaceToStore(place)));
   }, [testPlaces]);
 

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -4,15 +4,18 @@ import StoreList from "src/components/StoreList";
 import TextInputField from "src/components/TextInputField";
 import UserHeader from "src/components/UserHeader";
 import DebugBar from "./DebugBar";
-import { User, emptyUser, Store } from "src/interfaces";
+import { User, emptyUser, Store, GMapPlace } from "src/interfaces";
 import { getUserInfo } from "src/pages/Actions";
 import { Container } from "@material-ui/core";
 import { isDebug } from "src/config";
+import { transformGMapPlaceToStore } from "src/transforms";
 
 function Home(props: any) {
   const [userid, setUserid] = useState("");
   const [curUser, setCurUser] = useState<User>(emptyUser());
   const [stores, setStores] = useState<Store[]>([]);
+  const [testPlaces, setTestPlaces] = useState<GMapPlace[]>([]);
+  const [placeStore, setPlaceStore] = useState<Store[]>([]);
 
   useEffect(() => {
     // Initially set user based on passed props
@@ -28,12 +31,20 @@ function Home(props: any) {
     }
   }, [userid]);
 
+  useEffect(() => {
+    // Transform GMapPlace into Store
+    setPlaceStore(testPlaces.map((place) => transformGMapPlaceToStore(place)));
+  }, [testPlaces]);
+
   return (
     <Container disableGutters={false} className="Home">
       {isDebug && <TextInputField text={userid} setState={setUserid} />}
       <UserHeader user={curUser} />
-      {isDebug && <DebugBar storesCallback={setStores} />}
+      {isDebug && (
+        <DebugBar storesCallback={setStores} placesCallback={setTestPlaces} />
+      )}
       <StoreList stores={stores} />
+      <StoreList stores={placeStore} />
     </Container>
   );
 }

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -3,9 +3,8 @@ import { useHistory } from "react-router-dom";
 import TextInputField from "src/components/TextInputField";
 import { Container, Grid, Typography, Button } from "@material-ui/core";
 import { User, emptyUser, IdentityToken } from "src/interfaces";
-import { extractIdentityToken } from "src/utils";
 import { HOME_PAGE, TITLE_TEXT } from "src/constants";
-import { microapps, isWeb, isDebug } from "src/config";
+import { isWeb, isDebug } from "src/config";
 import { loginUser } from "src/pages/Actions";
 import Logo from "src/img/Logo.png";
 import "src/css/Login.css";
@@ -33,6 +32,7 @@ function Login() {
   const login = () => {
     const decodedIdentity: IdentityToken | null = loginUser();
     if (decodedIdentity) {
+      console.log(decodedIdentity);
       setUser(
         Object.assign({}, emptyUser(), {
           name: decodedIdentity.name,

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -32,7 +32,6 @@ function Login() {
   const login = () => {
     const decodedIdentity: IdentityToken | null = loginUser();
     if (decodedIdentity) {
-      console.log(decodedIdentity);
       setUser(
         Object.assign({}, emptyUser(), {
           name: decodedIdentity.name,

--- a/client/src/pages/ScanStore/ScanStore.tsx
+++ b/client/src/pages/ScanStore/ScanStore.tsx
@@ -25,8 +25,8 @@ import {
   MediaResponse,
   emptyMediaResponse,
 } from "src/interfaces";
-import { urlGetParam, fetchJson } from "src/utils";
-import { getStoreInfo } from "src/pages/Actions";
+import { urlGetParam } from "src/utils";
+import { getStoreInfo, getItem } from "src/pages/Actions";
 import { BrowserMultiFormatReader } from "@zxing/library";
 import {
   HOME_PAGE,
@@ -103,11 +103,7 @@ function ScanStore() {
   };
 
   const updateNewItem = async (barcode: string) => {
-    const data = {
-      "merchant-id": merchantID,
-      barcode: [barcode],
-    };
-    const [item]: Item[] = await fetchJson("POST", data, ITEM_LIST_API);
+    const item: Item = await getItem(barcode, merchantID);
     if (item) {
       updateCart([
         ...cartItems,

--- a/client/src/transforms.ts
+++ b/client/src/transforms.ts
@@ -1,0 +1,22 @@
+import { GMapPlace, Store, emptyStore } from "src/interfaces";
+import { MAX_CARD_HEIGHT } from "src/components/StoreCard/StoreCard";
+console.log(MAX_CARD_HEIGHT);
+
+// Transform GMapPlace response to Store interface for display
+export const transformGMapPlaceToStore = (gMapPlace: GMapPlace): Store => {
+  const newStore = emptyStore();
+  console.log(gMapPlace);
+  newStore["store-id"] = gMapPlace.place_id;
+  newStore["merchant-id"] = "GOOGLEMAPS"; //TODO(#114) We store an associative mapping?
+  newStore.name = gMapPlace.name;
+  newStore.latitude = gMapPlace.geometry.location.lat();
+  newStore.longitude = gMapPlace.geometry.location.lng();
+  newStore.business_status = gMapPlace.business_status;
+  newStore.vicinity = gMapPlace.vicinity;
+  // Decide whether the place we retrieved has a valid photo field
+  newStore.media = gMapPlace.icon; // Default to icon (always returned)
+  if (gMapPlace.photos && gMapPlace.photos.length > 0) {
+    newStore.media = gMapPlace.photos[0].getUrl({ maxHeight: MAX_CARD_HEIGHT });
+  }
+  return newStore;
+};

--- a/client/src/transforms.ts
+++ b/client/src/transforms.ts
@@ -14,6 +14,8 @@ export const transformGMapPlaceToStore = (gMapPlace: GMapPlace): Store => {
   // Decide whether the place we retrieved has a valid photo field
   newStore.media = gMapPlace.icon; // Default to icon (always returned)
   if (gMapPlace.photos && gMapPlace.photos.length > 0) {
+    // From: https://developers.google.com/places/web-service/search#PlaceSearchResults
+    // If any photos exist, it will only ever be [0]
     newStore.media = gMapPlace.photos[0].getUrl({ maxHeight: MAX_CARD_HEIGHT });
   }
   return newStore;

--- a/client/src/transforms.ts
+++ b/client/src/transforms.ts
@@ -1,11 +1,9 @@
 import { GMapPlace, Store, emptyStore } from "src/interfaces";
 import { MAX_CARD_HEIGHT } from "src/components/StoreCard/StoreCard";
-console.log(MAX_CARD_HEIGHT);
 
 // Transform GMapPlace response to Store interface for display
 export const transformGMapPlaceToStore = (gMapPlace: GMapPlace): Store => {
   const newStore = emptyStore();
-  console.log(gMapPlace);
   newStore["store-id"] = gMapPlace.place_id;
   newStore["merchant-id"] = "GOOGLEMAPS"; //TODO(#114) We store an associative mapping?
   newStore.name = gMapPlace.name;

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -6,7 +6,7 @@ const getJson = (res: any) => {
     let res_json = res.json();
     return res_json;
   } else {
-    alert(`Response code: ${res.status}`);
+    console.error(`Response code: ${res.status}`);
     return null;
   }
 };
@@ -17,14 +17,14 @@ const getText = (res: any) => {
   if (res.ok) {
     return res_text;
   } else {
-    alert(`Response code: ${res.status}`);
+    console.error(`Response code: ${res.status}`);
     return null;
   }
 };
 
 // Alert us to any errors in fetch
 const catchErr = (err: any) => {
-  alert("Error: " + err);
+  console.error("Error: " + err);
 };
 
 // fetch response from url

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -22,7 +22,9 @@ const getText = (res: any) => {
   }
 };
 
-// Alert us to any errors in fetch
+// Log to error any errors in fetch instead of alerts
+// which will not show up when debugging in microapps env
+// and is highly disruptive for user-flow on web
 const catchErr = (err: any) => {
   console.error("Error: " + err);
 };


### PR DESCRIPTION
- Cleaned up unused imports from #111 refactor
- Introduced `transform.ts` as a first step towards #115 
  - Transform an object with [PlaceResult](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult) interface to updated `Store` interface which allows for reuse of `<StoreList />` component with both server-retrieved stores as well as Places API retrieved stores
  - As a result of this update, added fields into `Store` interface that doesn't match with DB anymore, hence requiring #115
- Implemented picture retrieval with nearbyStores using `photos[0].getUrl()` with PlacesAPI (see #114 for context)
- Abstracted Location and Places API functions into `Actions.ts` from `DebugBar` component
- We no longer have any raw `fetch` calls from within our components, API-facing calls are all refactored into `pages/Actions.ts`
- Separation between pure UI components (`src/components/*`) and rich stateful components (`src/pages/*`)