### PR TITLE
Adding environment variables to client side to secure exposing keys and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.sublime-workspace
 **/__snapshots__/
 **/*.swp
+*.env
 
 # Temporary
 **/docs

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Open-source 2020 Google Internship project. ScanAndGo is a Spot-as-a-service app
 
 1. cd `/client`
 2. Install project dependencies by running `yarn install .`
-3. cd `/server`
-4. Install project dependencies by running `yarn install .`
+3. Obtain keys for required environment variables specified in `/client/env_template`
+   and store it in .env file. This file or any keys should not be checked in.
+4. cd `/server`
+5. Install project dependencies by running `yarn install .`
 
 ### Front-end Server (React)
 

--- a/client/env_template
+++ b/client/env_template
@@ -1,0 +1,2 @@
+REACT_APP_GOOGLE_MAPS_API_KEY=<add local asset>
+REACT_APP_MICROAPPS_CLIENT_ID=<add local asset>

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test -u --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject",
-    "create-env": "printenv > .env"
+    "create-env": "printenv | grep \"^REACT_APP_\"  > .env"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,8 @@
     "start": "serve -s build -l 80",
     "build": "react-scripts build",
     "test": "react-scripts test -u --env=jest-environment-jsdom-sixteen",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "create-env": "printenv > .env"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,8 +25,8 @@
       Link to CDN for microapps.js library?
     -->
     <script src="https://microapps.google.com/apis/v1alpha/microapps.js"></script>
-    <script id="mapPlacesAPIScript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBkGOvn8gUfLrECXPQ5KFNCHUqoXr3mzCc&libraries=places"></script>
-    <title>ScanAndGo GPay</title>
+    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_MAPS_API_KEY%&libraries=places"></script>
+    <title>ScanAndGo Pay</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -26,7 +26,7 @@
     -->
     <script src="https://microapps.google.com/apis/v1alpha/microapps.js"></script>
     <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_MAPS_API_KEY%&libraries=places"></script>
-    <title>ScanAndGo Pay</title>
+    <title>ScanAndGo GPay</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -25,7 +25,10 @@
       Link to CDN for microapps.js library?
     -->
     <script src="https://microapps.google.com/apis/v1alpha/microapps.js"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_MAPS_API_KEY%&libraries=places"></script>
+    <script
+      id="mapPlacesAPIScript"
+      src="https://maps.googleapis.com/maps/api/js?key=%REACT_APP_GOOGLE_MAPS_API_KEY%&libraries=places"
+    ></script>
     <title>ScanAndGo GPay</title>
   </head>
   <body>

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,25 +2,26 @@ steps:
   - name: node:10
     entrypoint: yarn
     args:
-      - create-env
-    id: "client-env"
-    dir: "client/"
-    env:
-      - "REACT_APP_GOOGLE_MAPS_API_KEY=${_GOOGLE_MAPS_API_KEY}"
-      - "REACT_APP_MICROAPPS_CLIENT_ID=${_MICROAPPS_CLIENT_ID}"
-  - name: node:10
-    entrypoint: yarn
-    args:
       - install
     id: "client-install"
     dir: "client/"
   - name: node:10
     entrypoint: yarn
     args:
+      - create-env
+    id: "client-env"
+    dir: "client/"
+    env:
+      - "REACT_APP_GOOGLE_MAPS_API_KEY=${_GOOGLE_MAPS_API_KEY}"
+      - "REACT_APP_MICROAPPS_CLIENT_ID=${_MICROAPPS_CLIENT_ID}"
+    waitFor: ["client-install"]
+  - name: node:10
+    entrypoint: yarn
+    args:
       - build
     id: "client-build"
     dir: "client/"
-    waitFor: ["client-install", "client-env"]
+    waitFor: ["client-env"]
   - name: "gcr.io/cloud-builders/gcloud"
     args: ["app", "deploy"]
     dir: "client/"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,15 @@ steps:
   - name: node:10
     entrypoint: yarn
     args:
+      - create-env
+    id: "client-env"
+    dir: "client/"
+    env:
+      - "REACT_APP_GOOGLE_MAPS_API_KEY=${_GOOGLE_MAPS_API_KEY}"
+      - "REACT_APP_MICROAPPS_CLIENT_ID=${_MICROAPPS_CLIENT_ID}"
+  - name: node:10
+    entrypoint: yarn
+    args:
       - install
     id: "client-install"
     dir: "client/"
@@ -11,7 +20,7 @@ steps:
       - build
     id: "client-build"
     dir: "client/"
-    waitFor: ["client-install"]
+    waitFor: ["client-install", "client-env"]
   - name: "gcr.io/cloud-builders/gcloud"
     args: ["app", "deploy"]
     dir: "client/"
@@ -28,6 +37,6 @@ steps:
     dir: "server/"
     waitFor: ["server-build"]
     timeout: 300s
-    
+
 options:
   machineType: "N1_HIGHCPU_8"


### PR DESCRIPTION
- Removed currently configured API_KEY and use env variables in index.html (although it is still visible from commit history, so we need to regenerate this key and mark that as obsolete"
- Updated README with instructions to configure env variables
- Added env variables in GCP project with current values: https://screenshot.googleplex.com/QnuksJaBT9U.png
- Updated cloudbuild to take in env variable from GCP configured variables and add them in a .env file by running npm script [TO TEST]