### PR TITLE
Enabled usage of Android-like toast alerts exposed via function call to AppContext state

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^10.3.0",
     "@testing-library/user-event": "^7.1.2",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { Route, Switch } from "react-router-dom";
 import Login from "src/pages/Login";
 import Home from "src/pages/Home";
@@ -9,20 +9,33 @@ import AppTheme from "src/theme";
 import { isWeb } from "src/config";
 import { Container } from "@material-ui/core";
 import { ThemeProvider } from "@material-ui/core/styles";
+import { GlobalState } from "src/interfaces";
+import AlertBoxQueued from "src/components/AlertBoxQueued";
+
+export const AppContext = React.createContext({});
 
 function App() {
+  const [alerts, setAlerts] = useState<React.ReactElement[]>([]);
+
+  const globalState: GlobalState = {
+    alerts: { get: alerts, set: setAlerts },
+  };
+
   return (
     <main>
       <ThemeProvider theme={AppTheme}>
-        <Container disableGutters={!isWeb}>
-          <Switch>
-            <Route path="/" component={Login} exact />
-            <Route path="/home" component={Home} />
-            <Route path="/store" component={ScanStore} />
-            <Route path="/receipt" component={Receipt} />
-            <Route component={NotFound} />
-          </Switch>
-        </Container>
+        <AppContext.Provider value={globalState}>
+          <Container disableGutters={!isWeb}>
+            <Switch>
+              <Route path="/" component={Login} exact />
+              <Route path="/home" component={Home} />
+              <Route path="/store" component={ScanStore} />
+              <Route path="/receipt" component={Receipt} />
+              <Route component={NotFound} />
+            </Switch>
+            <AlertBoxQueued content={alerts} />
+          </Container>
+        </AppContext.Provider>
       </ThemeProvider>
     </main>
   );

--- a/client/src/components/AlertBoxQueued/AlertBoxQueued.test.tsx
+++ b/client/src/components/AlertBoxQueued/AlertBoxQueued.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import AlertBoxQueued from "./AlertBoxQueued";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("AlertBoxQueued Component Tests", () => {
+  const props = {};
+
+  it("AlertBoxQueued renders correctly", () => {
+    const tree = renderer.create(<AlertBoxQueued {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/client/src/components/AlertBoxQueued/AlertBoxQueued.tsx
+++ b/client/src/components/AlertBoxQueued/AlertBoxQueued.tsx
@@ -4,7 +4,6 @@ function AlertBoxQueued({ content }: { content: React.ReactElement[] }) {
   const [displayedAlert, setDisplayedAlert] = useState<
     React.ReactElement | undefined
   >();
-  const [alertQueue, setAlertQueue] = useState<React.ReactElement[]>([]);
   const [queue, setQueue] = useState<React.ReactElement[]>([]);
 
   const popContent = () => {
@@ -21,16 +20,8 @@ function AlertBoxQueued({ content }: { content: React.ReactElement[] }) {
   }, [queue]);
 
   useEffect(() => {
-    if (alertQueue.length) {
-      console.log(`addition: ${alertQueue.length}`);
-      setQueue([...alertQueue, ...queue]);
-      setAlertQueue([]);
-    }
-  }, [alertQueue]);
-
-  useEffect(() => {
     if (content) {
-      setAlertQueue(content);
+      setQueue([...content, ...queue]);
     }
   }, [content]);
 

--- a/client/src/components/AlertBoxQueued/AlertBoxQueued.tsx
+++ b/client/src/components/AlertBoxQueued/AlertBoxQueued.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+
+function AlertBoxQueued({ content }: { content: React.ReactElement[] }) {
+  const [displayedAlert, setDisplayedAlert] = useState<
+    React.ReactElement | undefined
+  >();
+  const [alertQueue, setAlertQueue] = useState<React.ReactElement[]>([]);
+  const [queue, setQueue] = useState<React.ReactElement[]>([]);
+
+  const popContent = () => {
+    queue.pop();
+    setQueue([...queue]);
+  };
+
+  useEffect(() => {
+    if (queue.length) {
+      setDisplayedAlert(queue[queue.length - 1]);
+    } else {
+      setDisplayedAlert(undefined);
+    }
+  }, [queue]);
+
+  useEffect(() => {
+    if (alertQueue.length) {
+      console.log(`addition: ${alertQueue.length}`);
+      setQueue([...alertQueue, ...queue]);
+      setAlertQueue([]);
+    }
+  }, [alertQueue]);
+
+  useEffect(() => {
+    if (content) {
+      setAlertQueue(content);
+    }
+  }, [content]);
+
+  return (
+    <div
+      className="AlertBoxQueued"
+      style={{
+        bottom: "0px",
+        position: "absolute",
+        width: "100%",
+        left: "0px",
+      }}
+    >
+      {displayedAlert &&
+        React.cloneElement(displayedAlert, {
+          closeCallback: popContent,
+        })}
+    </div>
+  );
+}
+
+export default AlertBoxQueued;

--- a/client/src/components/AlertBoxQueued/index.tsx
+++ b/client/src/components/AlertBoxQueued/index.tsx
@@ -1,0 +1,2 @@
+import AlertBoxQueued from "./AlertBoxQueued";
+export default AlertBoxQueued;

--- a/client/src/components/AlertToast/AlertToast.test.tsx
+++ b/client/src/components/AlertToast/AlertToast.test.tsx
@@ -3,14 +3,33 @@ import renderer from "react-test-renderer";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import AlertToast from "./AlertToast";
+import { deepHtmlStringMatch } from "src/utils";
+import { Button } from "@material-ui/core";
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe("AlertToast Component Tests", () => {
-  const props = {};
+  const mockedClose = jest.fn();
+  const props = {
+    content: <p id="test-content">Hello</p>,
+    style: { severity: "success" },
+    closeCallback: mockedClose,
+  };
 
-  it("AlertToast renders correctly", () => {
-    const tree = renderer.create(<AlertToast {...props} />).toJSON();
-    expect(tree).toMatchSnapshot();
+  //TODO(#171): react-test-renderer has trouble rendering <Alert />
+  //            cannot "getboundingclientrect" of null issue
+  //            apparently does not render child element?
+
+  it("AlertToast renders message", () => {
+    const wrapper = Enzyme.mount(<AlertToast {...props} />);
+    const content = wrapper.find("#test-content").last();
+    expect(deepHtmlStringMatch(content, "Hello"));
+  });
+
+  it("AlertToast calls close callback when closed", () => {
+    const wrapper = Enzyme.mount(<AlertToast {...props} />);
+    const closeBtn = wrapper.find({ type: "button", title: "Close" }).last();
+    closeBtn.simulate("click");
+    expect(mockedClose).toBeCalled();
   });
 });

--- a/client/src/components/AlertToast/AlertToast.test.tsx
+++ b/client/src/components/AlertToast/AlertToast.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import AlertToast from "./AlertToast";
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe("AlertToast Component Tests", () => {
+  const props = {};
+
+  it("AlertToast renders correctly", () => {
+    const tree = renderer.create(<AlertToast {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/client/src/components/AlertToast/AlertToast.tsx
+++ b/client/src/components/AlertToast/AlertToast.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from "react";
+import { Container, Slide } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
+import { useTheme } from "@material-ui/core/styles";
+
+function AlertToast({
+  content,
+  style,
+  closeCallback,
+}: {
+  content: React.ReactElement;
+  style: {
+    severity: "error" | "success" | "info" | "warning" | undefined;
+    variant?: "outlined" | "standard" | "filled" | undefined;
+    icon?: React.ReactElement;
+  };
+  closeCallback?: () => void;
+}) {
+  const [showAlert, setShowAlert] = useState<boolean>(true);
+
+  const theme = useTheme();
+
+  const alertDismissCallback = () => {
+    console.log("dismissed alert");
+    setShowAlert(false);
+    if (closeCallback) closeCallback();
+  };
+
+  useEffect(() => {
+    console.log("mounting");
+    console.log(closeCallback);
+    // call dismiss alert callback when alert unmounts from DOM
+    if (closeCallback) {
+      return () => {
+        console.log("unmounting alert");
+      };
+    }
+  }, []);
+
+  return (
+    <Slide
+      direction="up"
+      in={showAlert}
+      style={{ margin: theme.spacing(4) }}
+      mountOnEnter
+      unmountOnExit
+    >
+      <Alert
+        className="AlertToast"
+        onClose={alertDismissCallback}
+        severity={style.severity}
+        variant={style.variant}
+        icon={style.icon}
+      >
+        {content}
+      </Alert>
+    </Slide>
+  );
+}
+
+export default AlertToast;

--- a/client/src/components/AlertToast/AlertToast.tsx
+++ b/client/src/components/AlertToast/AlertToast.tsx
@@ -8,7 +8,7 @@ function AlertToast({
   style,
   closeCallback,
 }: {
-  content: React.ReactElement;
+  content: React.ReactElement | string;
   style: {
     severity: "error" | "success" | "info" | "warning" | undefined;
     variant?: "outlined" | "standard" | "filled" | undefined;
@@ -21,21 +21,9 @@ function AlertToast({
   const theme = useTheme();
 
   const alertDismissCallback = () => {
-    console.log("dismissed alert");
     setShowAlert(false);
     if (closeCallback) closeCallback();
   };
-
-  useEffect(() => {
-    console.log("mounting");
-    console.log(closeCallback);
-    // call dismiss alert callback when alert unmounts from DOM
-    if (closeCallback) {
-      return () => {
-        console.log("unmounting alert");
-      };
-    }
-  }, []);
 
   return (
     <Slide

--- a/client/src/components/AlertToast/index.tsx
+++ b/client/src/components/AlertToast/index.tsx
@@ -1,0 +1,2 @@
+import AlertToast from "./AlertToast";
+export default AlertToast;

--- a/client/src/components/MediaScanner/MediaScanner.tsx
+++ b/client/src/components/MediaScanner/MediaScanner.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { isWeb, microapps } from "src/config";
-import { MediaResponse, emptyMediaResponse } from "src/interfaces";
+import { MediaResponse, emptyMediaResponse, GlobalState } from "src/interfaces";
 import { processImageBarcode } from "src/utils";
+import AlertToast from "src/components/AlertToast";
+import { AppContext } from "src/App";
 
 function MediaScanner({
   button,
@@ -16,6 +18,7 @@ function MediaScanner({
 
   const uploadedImgId = "media-img-upload";
   const debugImgId = "media-img-debug";
+  const appContext = useContext(AppContext) as GlobalState;
 
   const requestMediaUpload = async () => {
     if (isWeb) {
@@ -38,9 +41,21 @@ function MediaScanner({
     } else {
       return;
     }
-    processImageBarcode(img).then((barcode: string) => {
-      resultCallback(barcode);
-    });
+    processImageBarcode(img)
+      .then((barcode: string) => {
+        resultCallback(barcode);
+      })
+      .catch((err: any) => {
+        if (appContext.alerts) {
+          appContext.alerts.set([
+            <AlertToast
+              key={new Date().getTime()}
+              content={`Scanner error: ${err}`}
+              style={{ severity: "error" }}
+            />,
+          ]);
+        }
+      });
   };
 
   useEffect(() => {

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -5,6 +5,7 @@
  * database documents as well as API json responses.
  *
  */
+import React from "react";
 
 export interface Item {
   barcode: string; // SKU identifier
@@ -130,3 +131,10 @@ export const emptyGeoLocation = (): GeoLocation => ({
     longitude: 0.0,
   },
 });
+
+export interface GlobalState {
+  alerts: {
+    get: React.ReactElement[];
+    set: (alerts: React.ReactElement[]) => void;
+  };
+}

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { withRouter, useHistory } from "react-router-dom";
 import StoreList from "src/components/StoreList";
 import TextInputField from "src/components/TextInputField";
@@ -7,8 +7,17 @@ import DebugBar from "./DebugBar";
 import IconSearchBar from "src/components/IconSearchBar";
 import LocationOnIcon from "@material-ui/icons/LocationOn";
 import LocationOffIcon from "@material-ui/icons/LocationOff";
+import AlertToast from "src/components/AlertToast";
+import { AppContext } from "src/App";
 import { SCANSTORE_PAGE } from "src/constants";
-import { User, emptyUser, Store, GMapPlace, GeoLocation } from "src/interfaces";
+import {
+  User,
+  emptyUser,
+  Store,
+  GMapPlace,
+  GeoLocation,
+  GlobalState,
+} from "src/interfaces";
 import {
   getUserInfo,
   getGeoLocation,
@@ -31,6 +40,7 @@ function Home(props: any) {
     null
   );
   const history = useHistory();
+  const appContext = useContext(AppContext) as GlobalState;
 
   const SECRET_TRIGGER = "hungry";
 
@@ -75,6 +85,15 @@ function Home(props: any) {
       history.push(SCANSTORE_PAGE + "?id=" + storeId + "&mid=" + merchantId);
     } else {
       //TODO(#65) Let user know that QR is malformed
+      if (appContext.alerts) {
+        appContext.alerts.set([
+          <AlertToast
+            key={new Date().getTime()}
+            content={`Malformed store QR: ${storeUrl}`}
+            style={{ severity: "error" }}
+          />,
+        ]);
+      }
     }
   };
 

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,26 +1,28 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { useHistory } from "react-router-dom";
 import TextInputField from "src/components/TextInputField";
 import { Grid, Typography, Button } from "@material-ui/core";
-import { User, emptyUser, IdentityToken } from "src/interfaces";
+import { GlobalState, User, emptyUser, IdentityToken } from "src/interfaces";
 import { HOME_PAGE, TITLE_TEXT } from "src/constants";
 import { isWeb, isDebug } from "src/config";
 import { loginUser } from "src/pages/Actions";
+import AlertToast from "src/components/AlertToast";
 import Logo from "src/img/Logo.png";
 import "src/css/Login.css";
+import { AppContext } from "src/App";
 declare const window: any;
 
 function Login() {
   const logoSpinnerSpeed = 3;
 
   const history = useHistory();
+  const appContext: GlobalState = useContext(AppContext) as GlobalState;
 
   // Flag for us to manually run login on mobile
   const [loginError, setLoginError] = useState(false);
   const [user, setUser] = useState<User>(emptyUser());
 
   const updateUser = (text: string) => {
-    //setIdentity(Object.assign({}, emptyIdentityToken(), { sub: text }));
     setUser(
       Object.assign({}, emptyUser(), {
         name: text,
@@ -40,6 +42,13 @@ function Login() {
         );
       } else {
         setLoginError(true);
+        appContext.alerts.set([
+          <AlertToast
+            key={new Date().getTime()}
+            content={<p>Login with Google in the microapp!</p>}
+            style={{ severity: "error" }}
+          />,
+        ]);
       }
     });
   };

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -16,7 +16,7 @@ function Login() {
   const logoSpinnerSpeed = 3;
 
   const history = useHistory();
-  const appContext: GlobalState = useContext(AppContext) as GlobalState;
+  const appContext = useContext(AppContext) as GlobalState;
 
   // Flag for us to manually run login on mobile
   const [loginError, setLoginError] = useState(false);
@@ -42,13 +42,15 @@ function Login() {
         );
       } else {
         setLoginError(true);
-        appContext.alerts.set([
-          <AlertToast
-            key={new Date().getTime()}
-            content={<p>Login with Google in the microapp!</p>}
-            style={{ severity: "error" }}
-          />,
-        ]);
+        if (appContext.alerts) {
+          appContext.alerts.set([
+            <AlertToast
+              key={new Date().getTime()}
+              content={"Login with Google in the microapp!"}
+              style={{ severity: "error" }}
+            />,
+          ]);
+        }
       }
     });
   };

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -175,7 +175,9 @@ export const processImageBarcode = async (img: HTMLImageElement) => {
     const result = await codeReader
       .decodeFromImage(img)
       .then((res: any) => res.text)
-      .catch((err: any) => null);
+      .catch((err: any) => {
+        throw err;
+      });
     if (result) {
       return result;
     }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1281,6 +1281,17 @@
   dependencies:
     "@babel/runtime" "^7.4.4"
 
+"@material-ui/lab@^4.0.0-alpha.56":
+  version "4.0.0-alpha.56"
+  resolved "https://registry.yarnpkg.com/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz#ff63080949b55b40625e056bbda05e130d216d34"
+  integrity sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.10.2"
+    clsx "^1.0.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
+
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"
@@ -1317,6 +1328,15 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.10.2.tgz#3fd5470ca61b7341f1e0468ac8f29a70bf6df321"
+  integrity sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
 
 "@material-ui/utils@^4.9.12", "@material-ui/utils@^4.9.6":
   version "4.9.12"


### PR DESCRIPTION
Sample:
```jsx
import { AppContext } from "src/App";
import { GlobalState } from "src/interfaces";
import AlertToast from "src/components/AlertToast";
function ... {
  const appContext = useContext(AppContext) as GlobalState; // Need to tell typescript what's in our context
  func ... {
    // Adds an AlertToast (@material-ui <Toast />) wrapper component
    // into the alerts queue via state update to AppContext
    appContext.alerts.set([
      <AlertToast content={React.ReactElement} style={} />,
      ... (1 or more)
    ]);
  }
}
```
Also notes the changes to `App.tsx` where an additional `<AppContext.Provider />` and `<AlertBoxQueued content={alerts} />` have been added. `<AppContext.Provider />` exposes the state update function to all children components and `<AlertBoxQueued />` specifies where alerts will be populated on our page. (In this case at the bottom - fixed, relative to our app container)

- Added tests for `<AlertToast />` component to check for rendering of specified content and dismiss button
  - snapshot test is temporarily taken out due to #171
- Known issue for duplicate alerts #172

Demo:
![ScanAndGo GPay (1)](https://user-images.githubusercontent.com/5269791/86551090-af850d00-bf76-11ea-8fd8-ef9f23d12730.gif)
