### PR TITLE
Set default alert duration, and alternate between qr code and order details in Receipt page

### DIFF
--- a/client/src/components/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/AlertSnackbar/AlertSnackbar.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import Snackbar, { SnackbarOrigin } from "@material-ui/core/Snackbar";
 import MuiAlert, { AlertProps } from "@material-ui/lab/Alert";
 import { AlertContext } from "src/contexts/AlertContext";
+import { DEFAULT_ALERT_DURATION } from "src/constants";
 
 // https://material-ui.com/components/snackbars/#customized-snackbars
 function Alert(props: AlertProps) {
@@ -12,14 +13,36 @@ const AlertSnackbar = () => {
   const { open, setOpen, alertMessage, alertSeverity } = useContext(
     AlertContext
   );
+  const [duration, setDuration] = React.useState<number>(0);
   const anchorOrigin: SnackbarOrigin = {
     vertical: "top",
     horizontal: "center",
   };
 
+  const handleClose = (event?: React.SyntheticEvent, reason?: string) => {
+    setOpen(false);
+  };
+
+  React.useEffect(() => {
+    if (!open) {
+      setDuration(0);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (open && alertMessage) {
+      setDuration(duration + DEFAULT_ALERT_DURATION);
+    }
+  }, [alertMessage, alertSeverity]);
+
   return (
-    <Snackbar open={open} anchorOrigin={anchorOrigin}>
-      <Alert onClose={() => setOpen(false)} severity={alertSeverity}>
+    <Snackbar
+      open={open}
+      anchorOrigin={anchorOrigin}
+      autoHideDuration={duration}
+      onClose={handleClose}
+    >
+      <Alert onClose={handleClose} severity={alertSeverity}>
         {alertMessage}
       </Alert>
     </Snackbar>

--- a/client/src/components/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/AlertSnackbar/AlertSnackbar.tsx
@@ -20,6 +20,9 @@ const AlertSnackbar = () => {
   };
 
   const handleClose = (event?: React.SyntheticEvent, reason?: string) => {
+    if (reason === "clickaway") {
+      return;
+    }
     setOpen(false);
   };
 

--- a/client/src/components/AlertSnackbar/AlertSnackbar.tsx
+++ b/client/src/components/AlertSnackbar/AlertSnackbar.tsx
@@ -20,6 +20,7 @@ const AlertSnackbar = () => {
   };
 
   const handleClose = (event?: React.SyntheticEvent, reason?: string) => {
+    // don't close the alert if the user clicks on any part outside the alert snackbar
     if (reason === "clickaway") {
       return;
     }

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -32,6 +32,7 @@ export const DEFAULT_USER_HEADER_SUBTITLE =
 export const DEFAULT_CART_HEADER_TITLE = "My Cart";
 export const DEFAULT_STORE_HEADER_SUBTITLE = "Currently Shopping @";
 export const DEFAULT_BACK_BTN_TEXT = "back";
+export const DEFAULT_ALERT_DURATION = 3000;
 export const PRICE_FRACTION_DIGITS = 2;
 export const GEO_PRECISION_DIGITS = 3;
 export const PLACES_RADIUS_METERS = "5000";

--- a/client/src/css/App.css
+++ b/client/src/css/App.css
@@ -1,5 +1,6 @@
 .App {
   text-align: center;
+  vertical-align: top;
 }
 
 .App-logo {

--- a/client/src/css/Receipt.css
+++ b/client/src/css/Receipt.css
@@ -1,5 +1,5 @@
 .receipt {
-  height: 96vh;
+  height: 94vh;
   width: 90%;
   margin: 2vh 5vw;
   padding: 0;
@@ -11,18 +11,19 @@
 
 .qrCode {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 #canvas {
-  margin: 0 auto;
-  display: block;
-  width: auto;
-  max-width: 100vw;
-  max-height: 100vh;
+  max-width: 100%;
+  max-height: 100%;
 }
 
 .contents {
-  flex: 2;
+  flex: 1;
   overflow: auto;
   margin-bottom: 5%;
 }

--- a/client/src/css/index.css
+++ b/client/src/css/index.css
@@ -5,6 +5,10 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  height: 100vh;
+  padding: 0;
+  margin: 0;
+  vertical-align: top;
 }
 
 code {

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -7,6 +7,7 @@ import QRCode from "qrcode";
 import { HOME_PAGE, PAYMENT_STATUS } from "src/constants";
 import { AlertContext } from "src/contexts/AlertContext";
 import "src/css/Receipt.css";
+import { CartItem } from "src/interfaces";
 declare const window: any;
 
 const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
@@ -35,10 +36,16 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
 
   const generateQR = () => {
     const text = `$Order ID: ${orderId}`;
-    const width = parseInt(
+
+    const divHeight = parseInt(
       window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("height"),
       10
     );
+    const divWidth = parseInt(
+      window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("width"),
+      10
+    );
+    const width = Math.min(divHeight, divWidth);
     QRCode.toCanvas(
       document.getElementById("canvas"),
       text,
@@ -70,16 +77,33 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
     });
   };
 
+  const [viewQr, setViewQr] = useState(true);
+  const changeView = () => {
+    setViewQr(!viewQr);
+  };
+
   return (
     <div className="receipt">
       <Typography variant="h4">Receipt</Typography>
-      <div className="qrCode" ref={qrCodeDiv}>
+      <div
+        className="qrCode"
+        onClick={changeView}
+        style={{ display: viewQr ? "flex" : "none" }}
+        hidden={!viewQr}
+        ref={qrCodeDiv}
+      >
         <canvas id="canvas" />
+        <Typography>
+          Please show this to the cashier for verification.
+        </Typography>
+        <Typography>Tap to see order details.</Typography>
       </div>
-      <div className="contents">
-        <Typography variant="h6">Order details</Typography>
-        {contents && <Cart contents={contents} collapse={true} />}
-      </div>
+      {!viewQr && <Typography variant="h6">Order details</Typography>}
+      {!viewQr && (
+        <div className="contents" onClick={changeView} hidden={viewQr}>
+          {contents && <Cart contents={contents} collapse={true} />}
+        </div>
+      )}
       <Button
         onClick={returnToHome}
         className="button"

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -56,7 +56,7 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
       setPaymentStatus(PAYMENT_STATUS.SUCCESS);
     }, 3000);
     generateQR();
-  }, [generateQR, verify]);
+  }, []);
 
   useEffect(() => {
     if (paymentStatus === PAYMENT_STATUS.SUCCESS) {


### PR DESCRIPTION
* Alerts had to be closed manually previously; now, "new" alerts disappear after a default duration
  * "New" alerts refer to when the `alertMessage` or `alertSeverity` state is updated, and the snackbar is open
* Receipt page shows QR code by default, and tapping it will show the order details instead (and vice versa)
  * This allows QR code to take a bigger portion of the screen, as per discussion with @devYaoYH 
![ScanAndGo GPay (1)](https://user-images.githubusercontent.com/21990896/86696250-dc512700-c03f-11ea-93fb-23e6b7f1850d.gif)
