### PR TITLE
Added missing dependency in server: 'dotenv'

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "@google-cloud/firestore": "^3.8.5",
     "compression": "^1.7.4",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
     "jest": "^26.0.1",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2479,6 +2479,11 @@ dotenv@^6.1.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
Background: /api/ server responds with Error 500 when deployed to AppEngine but runs fine locally
Fix: Added dependency 'dotenv' into package.json.
Info: Dev-dependency `firebase-tools` required this dependency and since we start server locally in dev mode, no complaints, however, when deploy onto GCP AppEngine, starts crashing as 'dotenv' was not added into prod dependencies