### PR TITLE
[Receipt] Mock checkout flow, clean up UI

### DIFF
--- a/client/src/components/Cart/Cart.tsx
+++ b/client/src/components/Cart/Cart.tsx
@@ -15,10 +15,12 @@ function Cart({
   contents,
   collapse,
   updateItemQuantity,
+  showMedia = true,
 }: {
   contents: CartItem[];
   collapse: boolean;
   updateItemQuantity?: (barcode: string, quantity: number) => void;
+  showMedia?: boolean;
 }) {
   return (
     <div className="Cart">
@@ -32,7 +34,7 @@ function Cart({
               : () => {},
           };
           return collapse ? (
-            <ItemCardCompact {...cardProps} />
+            <ItemCardCompact {...cardProps} showMedia={showMedia} />
           ) : (
             <ItemCard {...cardProps} />
           );

--- a/client/src/components/ItemCardCompact/ItemCardCompact.tsx
+++ b/client/src/components/ItemCardCompact/ItemCardCompact.tsx
@@ -5,7 +5,13 @@ import { getSubtotalPrice } from "src/utils";
 import { Typography, Card, Grid, Divider } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
 
-function ItemCard({ cartItem }: { cartItem: CartItem }) {
+function ItemCard({
+  cartItem,
+  showMedia = true,
+}: {
+  cartItem: CartItem;
+  showMedia?: boolean;
+}) {
   const theme = useTheme();
   const themeSpacing = theme.spacing(1);
 
@@ -21,9 +27,11 @@ function ItemCard({ cartItem }: { cartItem: CartItem }) {
         justify="space-between"
         alignItems="center"
       >
-        <Grid item xs={3}>
-          <p>Media</p>
-        </Grid>
+        {showMedia && (
+          <Grid item xs={3}>
+            <p>Media</p>
+          </Grid>
+        )}
         <Grid item xs={3}>
           <Typography variant="body1">{cartItem.item.name}</Typography>
         </Grid>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -53,6 +53,7 @@ export enum DAY_PERIOD {
   NIGHT = "Night",
 }
 export enum PAYMENT_STATUS {
+  AWAITING = "AWAITING", // awaiting payment, not yet initiated
   SUBMITTED = "SUBMITTED", // pending transaction
   SUCCESS = "SUCCESS", // completed transaction
   FAILURE = "FAILURE",

--- a/client/src/css/Receipt.css
+++ b/client/src/css/Receipt.css
@@ -35,6 +35,15 @@
   margin-bottom: 2%;
 }
 
+.payment {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  /* overflow: hidden; */
+}
+
 .button {
   width: 95%;
   font-size: "14px";

--- a/client/src/css/Receipt.css
+++ b/client/src/css/Receipt.css
@@ -22,10 +22,17 @@
   max-height: 100%;
 }
 
-.contents {
+.order {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow: auto;
-  margin-bottom: 5%;
+}
+
+.details {
+  flex: 1;
+  overflow: scroll;
+  margin-bottom: 2%;
 }
 
 .button {

--- a/client/src/css/Receipt.css
+++ b/client/src/css/Receipt.css
@@ -41,7 +41,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  /* overflow: hidden; */
 }
 
 .button {

--- a/client/src/css/animation.css
+++ b/client/src/css/animation.css
@@ -47,3 +47,27 @@
   background-size: 400% 400%;
   animation: gradientProgression 1.5s linear infinite;
 }
+
+@keyframes dots {
+  0%,
+  20% {
+    opacity: 0;
+    text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  40% {
+    opacity: 1;
+    text-shadow: 0.25em 0 0 rgba(0, 0, 0, 0), 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  60% {
+    text-shadow: 0.25em 0 0, 0.5em 0 0 rgba(0, 0, 0, 0);
+  }
+  80%,
+  100% {
+    text-shadow: 0.25em 0 0, 0.5em 0 0;
+  }
+}
+
+.trailing-dots:after {
+  content: ".";
+  animation: dots 1s steps(5, end) infinite;
+}

--- a/client/src/pages/Receipt/Receipt.test.tsx
+++ b/client/src/pages/Receipt/Receipt.test.tsx
@@ -1,40 +1,54 @@
 import React from "react";
 import renderer from "react-test-renderer";
+import { act } from "react-dom/test-utils";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import Receipt from "./Receipt";
 import { BrowserRouter as Router } from "react-router-dom";
 import QRCode from "qrcode";
 import { TEST_ORDER_ID } from "src/constants";
+import { waitFor } from "@testing-library/react";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-it("Receipt renders correctly", () => {
-  const tree = renderer
-    .create(
-      <Router>
-        {" "}
-        <Receipt />
-      </Router>
-    )
-    .toJSON();
+it("Receipt renders correctly", async () => {
+  let tree;
+  await renderer.act(async () => {
+    tree = renderer
+      .create(
+        <Router>
+          <Receipt />
+        </Router>
+      )
+      .toJSON();
+  });
   expect(tree).toMatchSnapshot();
 });
 
-it("Receipt renders QR code with order ID", () => {
+it("Receipt renders QR code with order ID", async () => {
   const testQRText = `$Order ID: ${TEST_ORDER_ID}`;
   jest
     .spyOn(URLSearchParams.prototype, "get")
-    .mockImplementationOnce((_) => TEST_ORDER_ID);
+    .mockImplementation((_) => TEST_ORDER_ID);
   const toCanvasStub = jest
     .spyOn(QRCode, "toCanvas")
     .mockImplementation(jest.fn());
-  const component = Enzyme.mount(
-    <Router>
-      <Receipt />
-    </Router>
-  );
-  expect(toCanvasStub).toBeCalledTimes(1);
+  jest.useFakeTimers();
+
+  await act(async () => {
+    const wrapper = Enzyme.mount(
+      <Router>
+        <Receipt />
+      </Router>
+    );
+    const btns = wrapper.find("button");
+    expect(btns).toHaveLength(1);
+    const makePaymentBtn = btns.first();
+    makePaymentBtn.simulate("click");
+    jest.runAllTimers();
+  });
+
+  await waitFor(() => expect(toCanvasStub).toBeCalledTimes(1));
   expect(toCanvasStub).toBeCalledWith(
     null,
     testQRText,

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext } from "react";
 import { withRouter, RouteComponentProps } from "react-router-dom";
 import Cart from "src/components/Cart";
 import { urlGetParam } from "src/utils";
-import { Button, Typography } from "@material-ui/core";
+import { Button, Typography, Grid } from "@material-ui/core";
 import QRCode from "qrcode";
 import { HOME_PAGE, PAYMENT_STATUS } from "src/constants";
 import { AlertContext } from "src/contexts/AlertContext";
@@ -12,9 +12,26 @@ declare const window: any;
 
 const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
   const orderId = urlGetParam("id");
-  const contents = history.location.state
-    ? (history.location.state as any)?.contents
-    : null;
+  const cheese: CartItem = {
+    item: {
+      name: "cheese",
+      price: 3.2,
+      "merchant-id": "WPANCUD",
+      barcode: "93245036",
+    },
+    quantity: 2,
+  };
+  const milk: CartItem = {
+    item: {
+      name: "milk",
+      price: 5.6,
+      "merchant-id": "WPANCUD",
+      barcode: "93202411",
+    },
+    quantity: 1,
+  };
+  const contents = [milk];
+  // const contents = [milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk];
   const [paymentStatus, setPaymentStatus] = useState<PAYMENT_STATUS>(
     PAYMENT_STATUS.SUBMITTED
   );
@@ -77,7 +94,7 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
     });
   };
 
-  const [viewQr, setViewQr] = useState(true);
+  const [viewQr, setViewQr] = useState(false);
   const changeView = () => {
     setViewQr(!viewQr);
   };
@@ -98,10 +115,37 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
         </Typography>
         <Typography>Tap to see order details.</Typography>
       </div>
-      {!viewQr && <Typography variant="h6">Order details</Typography>}
+      {/* {!viewQr && } */}
       {!viewQr && (
-        <div className="contents" onClick={changeView} hidden={viewQr}>
-          {contents && <Cart contents={contents} collapse={true} />}
+        <div className="order" hidden={viewQr}>
+          <Typography variant="h6">Order details</Typography>
+          <Grid
+            container
+            direction="row"
+            justify="space-between"
+            alignItems="center"
+            style={{ borderBottom: "2px solid" }}
+          >
+            <Grid item xs={3}>
+              <Typography variant="body1">Item</Typography>
+            </Grid>
+            <Grid item xs={2}>
+              <Typography variant="body1">Price</Typography>
+            </Grid>
+            <Grid item xs={2}>
+              <Typography variant="body1">Subtotal</Typography>
+            </Grid>
+            <Grid item xs={2}>
+              <Typography variant="body1" align="center">
+                Quantity
+              </Typography>
+            </Grid>
+          </Grid>
+          <div className="details" onClick={changeView}>
+            {contents && (
+              <Cart contents={contents} collapse={true} showMedia={false} />
+            )}
+          </div>
         </div>
       )}
       <Button

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -7,53 +7,52 @@ import QRCode from "qrcode";
 import { HOME_PAGE, PAYMENT_STATUS } from "src/constants";
 import { AlertContext } from "src/contexts/AlertContext";
 import "src/css/Receipt.css";
+import "src/css/animation.css";
 import { CartItem } from "src/interfaces";
 declare const window: any;
 
 const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
   const orderId = urlGetParam("id");
-  const cheese: CartItem = {
-    item: {
-      name: "cheese",
-      price: 3.2,
-      "merchant-id": "WPANCUD",
-      barcode: "93245036",
-    },
-    quantity: 2,
-  };
-  const milk: CartItem = {
-    item: {
-      name: "milk",
-      price: 5.6,
-      "merchant-id": "WPANCUD",
-      barcode: "93202411",
-    },
-    quantity: 1,
-  };
-  const contents = [milk];
-  // const contents = [milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk, cheese, milk];
+  const { contents } = (history.location.state as any) || [];
   const [paymentStatus, setPaymentStatus] = useState<PAYMENT_STATUS>(
-    PAYMENT_STATUS.SUBMITTED
+    PAYMENT_STATUS.AWAITING
   );
   const { setOpen, setAlertSeverity, setAlertMessage } = useContext(
     AlertContext
   );
   const qrCodeDiv: React.RefObject<HTMLInputElement> = React.createRef();
+  const [viewQr, setViewQr] = useState(false);
+
+  useEffect(() => {
+    if (paymentStatus === PAYMENT_STATUS.SUCCESS) {
+      confirm();
+      generateQR();
+    }
+  }, [paymentStatus]);
+
+  const makePayment = () => {
+    verify();
+    // TODO (#50): Replace timeout mock with actual payflow
+    setTimeout(() => {
+      setPaymentStatus(PAYMENT_STATUS.SUCCESS);
+    }, 3000);
+  };
 
   const verify = () => {
-    setAlertSeverity("info");
-    setAlertMessage(`Verifying payment, please wait...`);
-    setOpen(true);
+    setViewQr(true);
+    setPaymentStatus(PAYMENT_STATUS.SUBMITTED);
   };
 
   const confirm = () => {
     setAlertSeverity("success");
     setAlertMessage(`Order ${orderId} Confimed!`);
+    setOpen(true);
   };
 
   const generateQR = () => {
     const text = `$Order ID: ${orderId}`;
 
+    console.log(qrCodeDiv);
     const divHeight = parseInt(
       window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("height"),
       10
@@ -73,91 +72,96 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
     );
   };
 
-  useEffect(() => {
-    verify();
-    // TODO (#50): Replace timeout mock with actual payflow
-    setTimeout(() => {
-      setPaymentStatus(PAYMENT_STATUS.SUCCESS);
-    }, 3000);
-    generateQR();
-  }, []);
-
-  useEffect(() => {
-    if (paymentStatus === PAYMENT_STATUS.SUCCESS) {
-      confirm();
-    }
-  }, [paymentStatus]);
-
   const returnToHome = () => {
     history.push({
       pathname: HOME_PAGE,
     });
   };
 
-  const [viewQr, setViewQr] = useState(false);
   const changeView = () => {
+    if (paymentStatus === PAYMENT_STATUS.AWAITING) {
+      return;
+    }
     setViewQr(!viewQr);
   };
 
   return (
     <div className="receipt">
       <Typography variant="h4">Receipt</Typography>
-      <div
-        className="qrCode"
-        onClick={changeView}
-        style={{ display: viewQr ? "flex" : "none" }}
-        hidden={!viewQr}
-        ref={qrCodeDiv}
-      >
-        <canvas id="canvas" />
-        <Typography>
-          Please show this to the cashier for verification.
-        </Typography>
-        <Typography>Tap to see order details.</Typography>
-      </div>
-      {/* {!viewQr && } */}
       {!viewQr && (
-        <div className="order" hidden={viewQr}>
+        <div className="order">
           <Typography variant="h6">Order details</Typography>
-          <Grid
-            container
-            direction="row"
-            justify="space-between"
-            alignItems="center"
-            style={{ borderBottom: "2px solid" }}
-          >
-            <Grid item xs={3}>
-              <Typography variant="body1">Item</Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body1">Price</Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body1">Subtotal</Typography>
-            </Grid>
-            <Grid item xs={2}>
-              <Typography variant="body1" align="center">
-                Quantity
-              </Typography>
-            </Grid>
-          </Grid>
+          <ReceiptHeader />
           <div className="details" onClick={changeView}>
-            {contents && (
-              <Cart contents={contents} collapse={true} showMedia={false} />
-            )}
+            <Cart contents={contents} collapse={true} showMedia={false} />
+            {/* TODO: uncomment below after merging #178 */}
+            {/* <CartSummary cartItems={contents}></CartSummary> */}
           </div>
         </div>
       )}
+      {paymentStatus === PAYMENT_STATUS.SUBMITTED && (
+        <div className="payment">
+          <Typography variant="h5" align="center" className={"trailing-dots"}>
+            Verifying payment, please wait
+          </Typography>
+        </div>
+      )}
+      {paymentStatus === PAYMENT_STATUS.SUCCESS && (
+        <div
+          className="qrCode"
+          onClick={changeView}
+          style={{ display: viewQr ? "flex" : "none" }}
+          hidden={!viewQr}
+          ref={qrCodeDiv}
+        >
+          <canvas id="canvas" />
+          <Typography align="center" color="textSecondary">
+            Please show this to the cashier for verification.
+          </Typography>
+          <Typography align="center" color="textSecondary">
+            Tap to see order details.
+          </Typography>
+        </div>
+      )}
       <Button
-        onClick={returnToHome}
+        onClick={
+          paymentStatus === PAYMENT_STATUS.AWAITING ? makePayment : returnToHome
+        }
         className="button"
         variant="contained"
         color="primary"
       >
-        Confirm Checkout
+        {paymentStatus === PAYMENT_STATUS.AWAITING
+          ? "Confirm Checkout"
+          : "Return to home"}
       </Button>
     </div>
   );
 };
+
+const ReceiptHeader = () => (
+  <Grid
+    container
+    direction="row"
+    justify="space-between"
+    alignItems="center"
+    style={{ borderBottom: "2px solid" }}
+  >
+    <Grid item xs={3}>
+      <Typography variant="body1">Item</Typography>
+    </Grid>
+    <Grid item xs={2}>
+      <Typography variant="body1">Price</Typography>
+    </Grid>
+    <Grid item xs={2}>
+      <Typography variant="body1">Subtotal</Typography>
+    </Grid>
+    <Grid item xs={2}>
+      <Typography variant="body1" align="center">
+        Quantity
+      </Typography>
+    </Grid>
+  </Grid>
+);
 
 export default withRouter(Receipt);

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -52,7 +52,6 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
   const generateQR = () => {
     const text = `$Order ID: ${orderId}`;
 
-    console.log(qrCodeDiv);
     const divHeight = parseInt(
       window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("height"),
       10
@@ -93,7 +92,9 @@ const Receipt: React.FC<RouteComponentProps> = ({ history }) => {
           <Typography variant="h6">Order details</Typography>
           <ReceiptHeader />
           <div className="details" onClick={changeView}>
-            <Cart contents={contents} collapse={true} showMedia={false} />
+            {contents && (
+              <Cart contents={contents} collapse={true} showMedia={false} />
+            )}
             {/* TODO: uncomment below after merging #178 */}
             {/* <CartSummary cartItems={contents}></CartSummary> */}
           </div>


### PR DESCRIPTION
* Make order details more compact, add header, fix overflow scroll
* Flow: Show order details -> User clicks "Confirm Checkout" -> Verify payment loading page (mock) -> Show QR code -> Return to home
![ScanAndGo GPay (2)](https://user-images.githubusercontent.com/21990896/86985289-860cf100-c1c3-11ea-9aec-2090c64a1dc3.gif)
