### PR TITLE
Fix auth redirect bugs

### DIFF
--- a/client/src/components/AuthenticatedRoute/AuthenticatedRoute.tsx
+++ b/client/src/components/AuthenticatedRoute/AuthenticatedRoute.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { AuthContext } from "src/contexts/AuthContext";
 import { emptyUser } from "src/interfaces";
 import { Redirect, RouteProps } from "react-router-dom";
@@ -20,10 +20,15 @@ const AuthenticatedRoute = (props: AuthenticatedRouteProps) => {
     AlertContext
   );
 
+  useEffect(() => {
+    if (user === emptyUser) {
+      setAlertMessage("Please login to access this page");
+      setAlertSeverity("error");
+      setOpen(true);
+    }
+  }, [user]);
+
   if (user === emptyUser) {
-    setAlertMessage("Please login to access this page");
-    setAlertSeverity("error");
-    setOpen(true);
     return (
       <Redirect
         to={{

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -59,8 +59,13 @@ function Login() {
 
   useEffect(() => {
     if (isWeb) {
-      // Wait for gapi to be initialized stackoverflow.com/questions/31640234/using-google-sign-in-button-with-react-2
-      window.addEventListener("google-loaded", renderGSigninButton);
+      // Render Google Sign-in button
+      if (window.gapi) {
+        renderGSigninButton();
+      } else {
+        // Wait for gapi to be initialized stackoverflow.com/questions/31640234/using-google-sign-in-button-with-react-2
+        window.addEventListener("google-loaded", renderGSigninButton);
+      }
     }
     // TODO (#163): synchronize login on microapp and web
     // Initial login if on microapp
@@ -78,7 +83,7 @@ function Login() {
 
   // Render Google Sign-in button in React component https://stackoverflow.com/a/59039972/
   const renderGSigninButton = () => {
-    gapi.signin2.render("g-signin2", {
+    window.gapi.signin2.render("g-signin2", {
       scope: "https://www.googleapis.com/auth/plus.login",
       longtitle: true,
       theme: "dark",


### PR DESCRIPTION
* Warning: Cannot update a component from inside the function body of a different component
  * Fix: update alert context within useEffect (ref: [so thread](https://stackoverflow.com/questions/60526786/react-warning-cannot-update-a-component-from-inside-the-function-body-of-a-diff))
* Redirect from checkout to login does not render google sign-in button
  * Fix: call `renderGSigninBtn` directly if `window.gapi` is initialized, otherwise wait for event listener