### PR TITLE
Make responsive font size for home btn icon and typography, and add home btn test

### DIFF
--- a/client/src/components/Header/Header.test.tsx
+++ b/client/src/components/Header/Header.test.tsx
@@ -3,6 +3,7 @@ import renderer from "react-test-renderer";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import Header from "./Header";
+import { HOME_PAGE } from "src/constants";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -17,6 +18,7 @@ describe("Header Component Tests", () => {
       </button>
     ),
     content: <p id="test-content">PAYLOAD</p>,
+    homeBtn: true,
   };
 
   it("Header renders correctly", () => {
@@ -37,5 +39,13 @@ describe("Header Component Tests", () => {
     const headerButton = wrapper.find("#test-btn").last();
     headerButton.simulate("click");
     expect(mockedClick).toBeCalled();
+  });
+
+  it("Header has home button and redurects to home page", async () => {
+    const wrapper = Enzyme.mount(<Header {...props} />);
+    const homeButton = wrapper.find("#home-btn").last();
+    homeButton.simulate("click");
+    const pushArgs = global.mockRedirectPush.mock.calls.pop();
+    expect(pushArgs[0]).toHaveProperty("pathname", HOME_PAGE);
   });
 });

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { isDebug } from "src/config";
-import { Typography, Paper, Grid, Box, Button } from "@material-ui/core";
+import { Paper, Grid, Button } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
+import { useStyles } from "src/styles";
 import HomeIcon from "@material-ui/icons/Home";
 import { useHistory } from "react-router-dom";
 import { HOME_PAGE } from "src/constants";
@@ -22,6 +22,7 @@ function Header({
   const theme = useTheme();
   const headerTopPadding = theme.spacing(2);
   const headerBotPadding = theme.spacing(4);
+  const classes = useStyles(theme);
 
   const history = useHistory();
   const returnToHome = () => {
@@ -49,13 +50,14 @@ function Header({
             <Grid container item xs={12} direction="row">
               {homeBtn && (
                 <Button
+                  id="home-btn"
                   onClick={returnToHome}
                   style={{
                     padding: `0 ${theme.spacing(2)}px 0 0 `,
                     minWidth: "0",
                   }}
                 >
-                  <HomeIcon fontSize="default" />
+                  <HomeIcon className={classes.icon} />
                 </Button>
               )}
               {title}

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -1,0 +1,12 @@
+import { Theme, makeStyles, createStyles } from "@material-ui/core/styles";
+
+export const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    icon: {
+      fontSize: theme.typography.h4.fontSize,
+      [theme.breakpoints.up("sm")]: {
+        fontSize: theme.typography.h3.fontSize,
+      },
+    },
+  })
+);

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,4 +1,4 @@
-import { createMuiTheme } from "@material-ui/core/styles";
+import { createMuiTheme, responsiveFontSizes } from "@material-ui/core/styles";
 import { Fab } from "@material-ui/core";
 
 const PRIMARY_COLOR = "#66BE64";
@@ -67,4 +67,4 @@ export const themeConfig = {
   default_card_img_height: "20vw",
 };
 
-export default AppTheme;
+export default responsiveFontSizes(AppTheme);


### PR DESCRIPTION
* Using Material UI's `responsiveFontSizes` to have responsive typography
* Using Material UI's styling hook API to have responsive icon size 
![ScanAndGo GPay (6)](https://user-images.githubusercontent.com/21990896/88504525-a03e3000-d007-11ea-899d-83ca5af03230.gif)
