### PR TITLE
Bug Fix for #213, #214, #219

### DIFF
--- a/client/src/components/CartHeader/CartHeader.tsx
+++ b/client/src/components/CartHeader/CartHeader.tsx
@@ -17,7 +17,7 @@ function CartHeader({
   content,
 }: {
   store: Store;
-  scanBarcodeCallback: (barcode: string) => Promise<void>;
+  scanBarcodeCallback: (barcode: string) => void;
   content?: React.ReactElement;
 }) {
   return (

--- a/client/src/components/MediaScanner/MediaScanner.tsx
+++ b/client/src/components/MediaScanner/MediaScanner.tsx
@@ -33,10 +33,10 @@ function MediaScanner({
   const scanBarcodeFromImage = () => {
     let img = document.getElementById(UPLOADED_IMG_ID) as HTMLImageElement;
     // Try to fallback, else abort
-    if (!img && debugFallbackImg) {
-      img = document.getElementById(DEBUG_IMG_ID) as HTMLImageElement;
-    } else {
-      return;
+    if (!img) {
+      if (debugFallbackImg) {
+        img = document.getElementById(DEBUG_IMG_ID) as HTMLImageElement;
+      } else return;
     }
     processImageBarcode(img).then((barcode: string) => {
       resultCallback(barcode);

--- a/client/src/components/MediaScanner/MediaScanner.tsx
+++ b/client/src/components/MediaScanner/MediaScanner.tsx
@@ -38,9 +38,13 @@ function MediaScanner({
         img = document.getElementById(DEBUG_IMG_ID) as HTMLImageElement;
       } else return;
     }
-    processImageBarcode(img).then((barcode: string) => {
-      resultCallback(barcode);
-    });
+    processImageBarcode(img)
+      .then((barcode: string) => {
+        resultCallback(barcode);
+      })
+      .catch((err: any) => {
+        //TODO(#59): Raise Error for barcode library failure
+      });
   };
 
   useEffect(() => {

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -82,8 +82,17 @@ function Home(props: any) {
 
   const scanStoreQRCallback = (storeUrl: string) => {
     // Try to extract store-id and merchant-id fields from storeUrl
-    const storeId = parseUrlParam(storeUrl, "id"); //TODO(#167) Replace with constants for "id"/"mid"
-    const merchantId = parseUrlParam(storeUrl, "mid");
+    const storeUrlArglist = storeUrl.split("?");
+    if (storeUrlArglist.length !== 2) {
+      //TODO(#65) Let user know that QR is malformed
+      // in this case, no url parameters detected
+      return;
+    }
+    // A correctly formed url will only contain 1 '?' character
+    // hence split will be array of length 2 always
+    const trimmedStoreUrl = storeUrlArglist[1];
+    const storeId = parseUrlParam(trimmedStoreUrl, "id"); //TODO(#167) Replace with constants for "id"/"mid"
+    const merchantId = parseUrlParam(trimmedStoreUrl, "mid");
     // If valid extraction, push us to new site
     if (storeId && merchantId) {
       history.push(getStoreRedirectUrl(storeId, merchantId));

--- a/client/src/pages/ScanStore/ScanStore.tsx
+++ b/client/src/pages/ScanStore/ScanStore.tsx
@@ -140,7 +140,7 @@ function ScanStore() {
         setCurItem(Object.assign({}, curItem, { quantity: quantity }));
         updateCartItem(barcode, quantity);
       }
-    } else {
+    } else if (quantity > 0) {
       // Call add new item to flow
       addCartItem(cartItem);
     }

--- a/client/src/pages/ScanStore/ScanStore.tsx
+++ b/client/src/pages/ScanStore/ScanStore.tsx
@@ -82,7 +82,7 @@ function ScanStore() {
   const { setAlert } = useContext(AlertContext);
 
   // Entry point for user scanning barcode
-  const scanItemToCart = async (barcode: string) => {
+  const scanItemToCart = (barcode: string) => {
     const existingItem = cartItems.find(
       (cartItem) => cartItem.item.barcode === barcode
     );
@@ -96,7 +96,8 @@ function ScanStore() {
   const updateNewItem = async (barcode: string) => {
     setLoadingItem(true);
     const item: Item = await getItem(barcode, merchantID);
-    if (!item.barcode) {
+    setLoadingItem(false);
+    if (!item || !item.barcode) {
       // TODO (#59): Notify user if barcode is invalid or item not found
       return;
     }
@@ -104,7 +105,6 @@ function ScanStore() {
       item: item,
       quantity: 1,
     };
-    setLoadingItem(false);
     // Experimental Flag: Toggle whether we raise dialog for adding item
     //                    or simply chuck it in immediately
     if (addDirect) {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -235,11 +235,12 @@ export const processImageBarcode = async (img: HTMLImageElement) => {
       const result = await codeReader
         .decodeFromImage(img)
         .then((res: any) => res.text)
-        .catch((err: any) => null);
+        .catch((err: any) => "");
       return result;
     }
   } catch (err) {
-    return null;
+    console.error(err);
+    throw err;
   }
 };
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -229,17 +229,18 @@ export const deepHtmlStringMatch = (element: any, match: string) => {
 
 // Given a HTML img element, process image data for barcode string
 export const processImageBarcode = async (img: HTMLImageElement) => {
-  const codeReader = new BrowserMultiFormatReader();
-  if (img) {
-    const result = await codeReader
-      .decodeFromImage(img)
-      .then((res: any) => res.text)
-      .catch((err: any) => null);
-    if (result) {
+  try {
+    const codeReader = new BrowserMultiFormatReader();
+    if (img) {
+      const result = await codeReader
+        .decodeFromImage(img)
+        .then((res: any) => res.text)
+        .catch((err: any) => null);
       return result;
     }
+  } catch (err) {
+    return null;
   }
-  return false;
 };
 
 // Jest does not load up image files by default


### PR DESCRIPTION
- StoreQR bug caused by problem with url parsing, `window.location.search` returns trimmed URL (matching `$?.*`) but we were passing the full store url (`https://scan-and....appspot.com/store?id=...&mid=...`) of which URLSearchParams is only able to grab `mid` and not `id`.
- Fixed logic error in MediaScanner resulting in barcodes not being able to scan
- Moved ghost loading termination flag earlier to resolve ghost loading not terminating on item query returning error
- Minor fix for empty item added to Cart from ItemDetail