### PR TITLE
Added expand button for ItemDetails if overflow is detected

### DIFF
--- a/client/src/components/ItemCard/ItemCardQuantityMixer.tsx
+++ b/client/src/components/ItemCard/ItemCardQuantityMixer.tsx
@@ -3,7 +3,7 @@ import { Fab, Typography, Grid } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 import RemoveIcon from "@material-ui/icons/Remove";
 import { useTheme, MuiThemeProvider } from "@material-ui/core/styles";
-import { InverseErrorTheme } from "src/theme";
+import { InverseAppTheme } from "src/theme";
 
 function ItemCardQuantityMixer({
   quantity,
@@ -25,11 +25,11 @@ function ItemCardQuantityMixer({
   };
 
   return (
-    <MuiThemeProvider theme={InverseErrorTheme}>
+    <MuiThemeProvider theme={InverseAppTheme}>
       <Grid container direction="row" justify="flex-end">
         <Grid item>
           <Fab
-            color="primary"
+            color="secondary"
             id="inc"
             onClick={increaseCounter}
             size="small"

--- a/client/src/components/ItemDetail/ItemDetail.tsx
+++ b/client/src/components/ItemDetail/ItemDetail.tsx
@@ -29,11 +29,23 @@ function ItemDetail({
   const [isRemoving, setIsRemoving] = useState<boolean>(false);
   const [isOverflow, setIsOverflow] = useState<boolean>(false);
   const [mediaCollapsed, setMediaCollapsed] = useState<boolean>(false);
+  const [minHeightMarginTop, setMinHeightMarginTop] = useState<number>(0);
 
   const theme = useTheme();
 
   const item = cartItem ? cartItem.item : emptyItem();
   const cornerRoundingRadius = "24px";
+
+  // Clamp minimum height for footer vh
+  const footerMinHeight = 180;
+  let footerPercentageHeight = 0.4;
+  if (
+    document.documentElement.clientHeight * footerPercentageHeight <
+    footerMinHeight
+  ) {
+    footerPercentageHeight =
+      footerMinHeight / document.documentElement.clientHeight;
+  }
 
   // Determine if is new item
   const isNewItem =
@@ -77,6 +89,17 @@ function ItemDetail({
     const contentDiv = document.getElementById("item-detail-description");
     if (contentDiv) setIsOverflow(checkContentOverflow(contentDiv));
     else setIsOverflow(false); // Cannot find content tag, no content to render
+    // Compute the margin required to offset minHeight for footer
+    const footerMarginOffset =
+      footerMinHeight -
+      document.documentElement.clientHeight * footerPercentageHeight;
+    if (footerMarginOffset > 0)
+      setMinHeightMarginTop(
+        Math.floor(
+          (100 * footerMarginOffset) / document.documentElement.clientHeight
+        )
+      );
+    else setMinHeightMarginTop(0);
   }, [cartItem]);
 
   return (
@@ -99,7 +122,7 @@ function ItemDetail({
       <div
         style={{
           width: "100vw",
-          height: "60vh",
+          height: `${Math.floor((1 - footerPercentageHeight) * 100)}vh`,
           overflow: "hidden",
           backgroundPosition: "center",
           backgroundSize: "cover",
@@ -140,8 +163,13 @@ function ItemDetail({
           style={{
             transition: "height 0.3s ease-out, margin-top 0.3s ease-out",
             width: "100%",
-            marginTop: mediaCollapsed ? "-50vh" : "0vh",
-            height: mediaCollapsed ? "90vh" : "40vh",
+            marginTop: mediaCollapsed
+              ? `-${90 - Math.floor(footerPercentageHeight * 100)}vh`
+              : "0vh",
+            height: mediaCollapsed
+              ? "90vh"
+              : `${Math.floor(footerPercentageHeight * 100)}vh`,
+            minHeight: "180px",
             backgroundColor: "#FFFFFF",
           }}
         >

--- a/client/src/components/ItemDetail/ItemDetail.tsx
+++ b/client/src/components/ItemDetail/ItemDetail.tsx
@@ -11,6 +11,7 @@ import {
   parseRawTextNewlines,
   checkContentOverflow,
 } from "src/utils";
+import { themeConfig } from "src/theme";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
@@ -29,12 +30,11 @@ function ItemDetail({
   const [isRemoving, setIsRemoving] = useState<boolean>(false);
   const [isOverflow, setIsOverflow] = useState<boolean>(false);
   const [mediaCollapsed, setMediaCollapsed] = useState<boolean>(false);
-  const [minHeightMarginTop, setMinHeightMarginTop] = useState<number>(0);
 
   const theme = useTheme();
 
   const item = cartItem ? cartItem.item : emptyItem();
-  const cornerRoundingRadius = "24px";
+  const cornerRoundingRadius = themeConfig.cornerRoundingRadius;
 
   // Clamp minimum height for footer vh
   const footerMinHeight = 180;
@@ -88,18 +88,7 @@ function ItemDetail({
     // Determine whether we should render 'show more' expand button
     const contentDiv = document.getElementById("item-detail-description");
     if (contentDiv) setIsOverflow(checkContentOverflow(contentDiv));
-    else setIsOverflow(false); // Cannot find content tag, no content to render
-    // Compute the margin required to offset minHeight for footer
-    const footerMarginOffset =
-      footerMinHeight -
-      document.documentElement.clientHeight * footerPercentageHeight;
-    if (footerMarginOffset > 0)
-      setMinHeightMarginTop(
-        Math.floor(
-          (100 * footerMarginOffset) / document.documentElement.clientHeight
-        )
-      );
-    else setMinHeightMarginTop(0);
+    else setIsOverflow(false);
   }, [cartItem]);
 
   return (
@@ -153,8 +142,15 @@ function ItemDetail({
               style={{ height: `${cornerRoundingRadius}` }}
               onClick={() => setMediaCollapsed(!mediaCollapsed)}
             >
-              {mediaCollapsed ? "Show Less" : "Show More"}
-              {mediaCollapsed ? <ExpandMoreIcon /> : <ExpandLessIcon />}
+              {mediaCollapsed ? (
+                <>
+                  Show Less <ExpandMoreIcon />
+                </>
+              ) : (
+                <>
+                  Show More <ExpandLessIcon />
+                </>
+              )}
             </Button>
           )}
         </div>

--- a/client/src/components/ItemDetail/ItemDetail.tsx
+++ b/client/src/components/ItemDetail/ItemDetail.tsx
@@ -6,7 +6,11 @@ import { useTheme, MuiThemeProvider } from "@material-ui/core/styles";
 import { ErrorTheme } from "src/theme";
 import ItemCardQuantityMixer from "src/components/ItemCard/ItemCardQuantityMixer";
 import { PRICE_FRACTION_DIGITS, PLACEHOLDER_ITEM_MEDIA } from "src/constants";
-import { getSubtotalPrice, parseRawTextNewlines } from "src/utils";
+import {
+  getSubtotalPrice,
+  parseRawTextNewlines,
+  checkContentOverflow,
+} from "src/utils";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 
@@ -37,11 +41,6 @@ function ItemDetail({
     !currentCart
       .map((curItem: CartItem) => curItem.item.barcode)
       .includes(item.barcode);
-
-  // Determine if our content has overflow and render expand button
-  const checkContentOverflow = (ele: HTMLElement) => {
-    return ele.clientHeight < ele.scrollHeight;
-  };
 
   // Callback for +/- mixer to update chosen item quantity
   const updateItemQuantityWrapper = (quantity: number) => {

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -6,6 +6,9 @@ const SECONDARY_COLOR = "#909090";
 const SUCCESS_COLOR = "#00E676";
 const ERROR_COLOR = "#F44336";
 
+const NEUTRAL_PRIMARY_COLOR = "#000000";
+const NEUTRAL_PRIMARY_COLOR_BLUE = "#2196f3";
+
 const WHITE_TEXT_COLOR = "white";
 const WHITE_BACKGROUND_COLOR = "#FFFFFF";
 
@@ -45,6 +48,15 @@ export const InverseAppTheme = createMuiTheme({
   },
 });
 
+export const NeutralAppTheme = createMuiTheme({
+  palette: {
+    primary: {
+      main: NEUTRAL_PRIMARY_COLOR,
+      contrastText: WHITE_TEXT_COLOR,
+    },
+  },
+});
+
 // Moving 'success' and 'error' into primary/secondary to allow
 // usage with majority of components (typescript + @material-ui constrain)
 export const ErrorTheme = createMuiTheme({
@@ -78,6 +90,7 @@ export const InverseErrorTheme = createMuiTheme({
 export const themeConfig = {
   max_card_height: 120,
   default_card_img_height: "20vw",
+  cornerRoundingRadius: "24px",
 };
 
 export default responsiveFontSizes(AppTheme);

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -32,6 +32,19 @@ const AppTheme = createMuiTheme({
   },
 });
 
+export const InverseAppTheme = createMuiTheme({
+  palette: {
+    primary: {
+      main: WHITE_BACKGROUND_COLOR,
+      contrastText: PRIMARY_COLOR,
+    },
+    secondary: {
+      main: WHITE_BACKGROUND_COLOR,
+      contrastText: SECONDARY_COLOR,
+    },
+  },
+});
+
 // Moving 'success' and 'error' into primary/secondary to allow
 // usage with majority of components (typescript + @material-ui constrain)
 export const ErrorTheme = createMuiTheme({

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -278,3 +278,8 @@ export const parseOrderName = (orderName: string) => {
   }
   return orderIds;
 };
+
+// Determine if a HTMLElement content has overflowed
+export const checkContentOverflow = (ele: HTMLElement) => {
+  return ele.clientHeight < ele.scrollHeight;
+};


### PR DESCRIPTION
- Detect whether content has overflow (for showing item description)
- Add a button to animate expand/collapse of footer details panel if overflow is detected

**Demo**

![ScanAndGo GPay (9)](https://user-images.githubusercontent.com/5269791/88616860-cb885400-d0c7-11ea-8895-5473a36213ae.gif)

