### PR TITLE
Receipt UI - qr code resizing, scrolling to order details, and loading qr code animation

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -22,6 +22,7 @@ export const BARCODE_PLACEHOLDER = "...barcode";
 export const ID_PLACEHOLDER = "...id";
 export const EMPTY_PLACEHOLDER = "";
 export const TITLE_TEXT = "ScanAndGo";
+export const SCALING_FACTOR = 3;
 // HTML DOM Handles
 export const GOOGLE_MAP_PLACEHOLDER_ID = "mapPlaceholder";
 export const GOOGLE_PLACES_SCRIPT_ID = "mapPlacesAPIScript";

--- a/client/src/pages/Receipt/Receipt.test.tsx
+++ b/client/src/pages/Receipt/Receipt.test.tsx
@@ -8,10 +8,7 @@ import { BrowserRouter as Router, useHistory } from "react-router-dom";
 import QRCode from "qrcode";
 import {
   TEST_ORDER_NAME,
-  HOME_PAGE,
-  ITEM_API,
   TEST_STORE_MERCHANT_ID,
-  SCANSTORE_PAGE,
   TEST_STORE_ID,
 } from "src/constants";
 import { waitFor } from "@testing-library/react";
@@ -57,14 +54,14 @@ it("Receipt renders correctly", async () => {
 it("Receipt renders QR code with order ID", async () => {
   const testQRText = `$Order: ${TEST_ORDER_NAME}.\n Contents: ${testContents}`;
   await act(async () => {
-    const wrapper = Enzyme.mount(
+    Enzyme.mount(
       <Router>
         <Receipt />
       </Router>
     );
   });
 
-  await waitFor(() => expect(toCanvasStub).toBeCalled());
+  await waitFor(() => expect(toCanvasStub).toBeCalledTimes(1));
   expect(toCanvasStub).toBeCalledWith(
     null,
     testQRText,

--- a/client/src/pages/Receipt/Receipt.test.tsx
+++ b/client/src/pages/Receipt/Receipt.test.tsx
@@ -61,7 +61,7 @@ it("Receipt renders QR code with order ID", async () => {
     );
   });
 
-  await waitFor(() => expect(toCanvasStub).toBeCalledTimes(1));
+  await waitFor(() => expect(toCanvasStub).toBeCalled());
   expect(toCanvasStub).toBeCalledWith(
     null,
     testQRText,

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -5,7 +5,7 @@ import Cart from "src/components/Cart";
 import { urlGetParam, parseOrderName } from "src/utils";
 import { Button, Typography, Grid, Collapse } from "@material-ui/core";
 import QRCode from "qrcode";
-import { HOME_PAGE, TEST_STORE_MERCHANT_ID } from "src/constants";
+import { TEST_STORE_MERCHANT_ID, SCALING_FACTOR } from "src/constants";
 import "src/css/Receipt.css";
 import { CartItem } from "src/interfaces";
 import Page from "src/pages/Page";
@@ -24,7 +24,9 @@ const Receipt: React.FC = () => {
   const [orderTimestamp, setOrderTimestamp] = useState("");
   const [storeId, setStoreId] = useState("");
   const qrCodeDiv: React.RefObject<HTMLDivElement> = React.createRef();
+  const orderRef: React.RefObject<HTMLDivElement> = React.createRef();
   const [showOrder, setShowOrder] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const { setAlert } = useContext(AlertContext);
 
   useEffect(() => {
@@ -32,33 +34,26 @@ const Receipt: React.FC = () => {
       setContents(res.contents);
       setOrderTimestamp(res.timestamp);
       setStoreId(res.storeId);
+      setIsLoading(false);
     });
   }, []);
 
   useEffect(() => {
-    if (contents) {
+    if (!isLoading) {
       generateQR();
     }
-  }, [contents]);
-
-  useEffect(() => {
-    generateQR();
-  }, [showOrder]);
+  }, [isLoading]);
 
   const generateQR = () => {
     const text = `$Order: ${orderName}.\n Contents: ${contents}`;
 
-    // Calculate QR code width to fit within screen (otherwise it defaults to a fixed size),
-    // taking into account space needed for text below QR code.
+    // Calculate maximum possible QR code width to fit within screen
+    // (otherwise it defaults to a fixed size)
     if (qrCodeDiv.current) {
-      const divHeight =
-        0.8 *
-        parseInt(
-          window
-            .getComputedStyle(qrCodeDiv.current)!
-            .getPropertyValue("height"),
-          10
-        );
+      const divHeight = parseInt(
+        window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("height"),
+        10
+      );
       const divWidth = parseInt(
         window.getComputedStyle(qrCodeDiv.current)!.getPropertyValue("width"),
         10
@@ -75,6 +70,35 @@ const Receipt: React.FC = () => {
           }
         }
       );
+    }
+  };
+
+  const enlargeQrCode = () => {
+    const canvas = document.getElementById("canvas");
+    if (canvas) {
+      canvas.style.height =
+        (parseInt(canvas.style.height) * SCALING_FACTOR).toString() + "px";
+      canvas.style.width =
+        (parseInt(canvas.style.width) * SCALING_FACTOR).toString() + "px";
+    }
+  };
+
+  const shrinkQrCode = () => {
+    const canvas = document.getElementById("canvas");
+    if (canvas) {
+      canvas.style.height =
+        (parseInt(canvas.style.height) / SCALING_FACTOR).toString() + "px";
+      canvas.style.width =
+        (parseInt(canvas.style.width) / SCALING_FACTOR).toString() + "px";
+    }
+  };
+
+  const scrollToOrder = () => {
+    if (orderRef.current) {
+      orderRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
     }
   };
 
@@ -102,9 +126,14 @@ const Receipt: React.FC = () => {
           <div className="qrCode" ref={qrCodeDiv}>
             <canvas id="canvas" />
           </div>
-          <div className="flex" style={{ flex: showOrder ? 3 : "none" }}>
-            <Grid onClick={() => setShowOrder(!showOrder)}>
-              <Button fullWidth={true} style={{ textTransform: "none" }}>
+          <div ref={orderRef}>
+            <Grid>
+              <Button
+                onClick={() => setShowOrder(!showOrder)}
+                disabled={isLoading}
+                fullWidth={true}
+                style={{ textTransform: "none" }}
+              >
                 {showOrder ? (
                   <div>
                     <ExpandLessIcon />
@@ -122,7 +151,13 @@ const Receipt: React.FC = () => {
                 )}
               </Button>
             </Grid>
-            <Collapse in={showOrder}>
+            <Collapse
+              timeout={0}
+              in={showOrder}
+              onEntered={scrollToOrder}
+              onEnter={shrinkQrCode}
+              onExit={enlargeQrCode}
+            >
               <div className="order">
                 <div className="details">
                   {contents && (

--- a/client/src/pages/Receipt/Receipt.tsx
+++ b/client/src/pages/Receipt/Receipt.tsx
@@ -14,6 +14,7 @@ import CartSummary from "src/components/CartSummary";
 import { getOrderDetails, getStoreRedirectUrl } from "../Actions";
 import ExpandLessIcon from "@material-ui/icons/ExpandLess";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import "src/css/animation.css";
 declare const window: any;
 
 const Receipt: React.FC = () => {
@@ -39,9 +40,7 @@ const Receipt: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!isLoading) {
-      generateQR();
-    }
+    generateQR();
   }, [isLoading]);
 
   const generateQR = () => {
@@ -59,13 +58,18 @@ const Receipt: React.FC = () => {
         10
       );
       const width = Math.min(divHeight, divWidth);
+      const options = { width };
+      if (isLoading) {
+        Object.assign(options, { color: { dark: "#80808080" } });
+      }
 
       QRCode.toCanvas(
         document.getElementById("canvas"),
         text,
-        { width: width },
+        options,
         (err) => {
           if (err) {
+            console.log(err);
             setAlert("error", `Unable to generate QR code `);
           }
         }
@@ -124,7 +128,10 @@ const Receipt: React.FC = () => {
             {orderTimestamp}
           </Typography>
           <div className="qrCode" ref={qrCodeDiv}>
-            <canvas id="canvas" />
+            <canvas
+              id="canvas"
+              className={isLoading ? "animate-flicker" : undefined}
+            />
           </div>
           <div ref={orderRef}>
             <Grid>


### PR DESCRIPTION
* Resize QR code by `SCALING_FACTOR` instead of regenerating it every time we view/hide order details
* Scroll to order details if needed
* Added QR code placeholder animation + disabled View order details while loading, because of #207 (Order details take awhile to load)

![ScanAndGo GPay (7)](https://user-images.githubusercontent.com/21990896/88738697-f88e4280-d16b-11ea-81c1-19df0ca45409.gif)
